### PR TITLE
Returner en DeltakerEndringResponse etter endring av deltaker

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/Application.kt
@@ -146,7 +146,7 @@ fun Application.module() {
     consumers.forEach { it.run() }
 
     configureAuthentication(environment)
-    configureRouting(pameldingService, deltakerService)
+    configureRouting(pameldingService, deltakerService, deltakerHistorikkService)
     configureMonitoring()
 
     val statusUpdateJob = StatusUpdateJob(leaderElection, attributes, deltakerStatusOppdateringService)

--- a/src/main/kotlin/no/nav/amt/deltaker/application/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/application/plugins/Routing.kt
@@ -13,6 +13,7 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import no.nav.amt.deltaker.application.registerHealthApi
+import no.nav.amt.deltaker.deltaker.DeltakerHistorikkService
 import no.nav.amt.deltaker.deltaker.DeltakerService
 import no.nav.amt.deltaker.deltaker.PameldingService
 import no.nav.amt.deltaker.deltaker.api.registerDeltakerApi
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory
 fun Application.configureRouting(
     pameldingService: PameldingService,
     deltakerService: DeltakerService,
+    deltakerHistorikkService: DeltakerHistorikkService,
 ) {
     install(StatusPages) {
         exception<IllegalArgumentException> { call, cause ->
@@ -42,7 +44,7 @@ fun Application.configureRouting(
         registerHealthApi()
 
         registerPameldingApi(pameldingService)
-        registerDeltakerApi(deltakerService)
+        registerDeltakerApi(deltakerService, deltakerHistorikkService)
 
         val catchAllRoute = "{...}"
         route(catchAllRoute) {

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/DeltakerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/DeltakerService.kt
@@ -33,12 +33,18 @@ class DeltakerService(
         deltakerRepository.deleteDeltakerOgStatus(deltakerId)
     }
 
-    suspend fun upsertEndretDeltaker(deltakerId: UUID, request: EndringRequest) {
+    suspend fun upsertEndretDeltaker(deltakerId: UUID, request: EndringRequest): Deltaker {
         val deltaker = get(deltakerId).getOrThrow()
 
-        deltakerEndringService
-            .upsertEndring(deltaker, request)
-            .onSuccess { endretDeltaker -> upsertDeltaker(endretDeltaker) }
+        return deltakerEndringService.upsertEndring(deltaker, request).fold(
+            onSuccess = { endretDeltaker ->
+                upsertDeltaker(endretDeltaker)
+                return@fold endretDeltaker
+            },
+            onFailure = {
+                return@fold deltaker
+            },
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApi.kt
@@ -1,53 +1,59 @@
 package no.nav.amt.deltaker.deltaker.api
 
-import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.post
+import io.ktor.util.pipeline.PipelineContext
+import no.nav.amt.deltaker.deltaker.DeltakerHistorikkService
 import no.nav.amt.deltaker.deltaker.DeltakerService
 import no.nav.amt.deltaker.deltaker.api.model.BakgrunnsinformasjonRequest
 import no.nav.amt.deltaker.deltaker.api.model.DeltakelsesmengdeRequest
+import no.nav.amt.deltaker.deltaker.api.model.EndringRequest
 import no.nav.amt.deltaker.deltaker.api.model.InnholdRequest
 import no.nav.amt.deltaker.deltaker.api.model.StartdatoRequest
+import no.nav.amt.deltaker.deltaker.api.model.toDeltakerEndringResponse
 import java.util.UUID
 
 fun Routing.registerDeltakerApi(
     deltakerService: DeltakerService,
+    historikkService: DeltakerHistorikkService,
 ) {
     authenticate("SYSTEM") {
         post("/deltaker/{deltakerId}/bakgrunnsinformasjon") {
             val request = call.receive<BakgrunnsinformasjonRequest>()
-            val deltakerId = UUID.fromString(call.parameters["deltakerId"])
-
-            deltakerService.upsertEndretDeltaker(deltakerId, request)
-            call.respond(HttpStatusCode.OK)
+            handleDeltakerEndring(deltakerService, request, historikkService)
         }
 
         post("/deltaker/{deltakerId}/innhold") {
             val request = call.receive<InnholdRequest>()
-            val deltakerId = UUID.fromString(call.parameters["deltakerId"])
-
-            deltakerService.upsertEndretDeltaker(deltakerId, request)
-            call.respond(HttpStatusCode.OK)
+            handleDeltakerEndring(deltakerService, request, historikkService)
         }
 
         post("/deltaker/{deltakerId}/deltakelsesmengde") {
             val request = call.receive<DeltakelsesmengdeRequest>()
-            val deltakerId = UUID.fromString(call.parameters["deltakerId"])
-
-            deltakerService.upsertEndretDeltaker(deltakerId, request)
-            call.respond(HttpStatusCode.OK)
+            handleDeltakerEndring(deltakerService, request, historikkService)
         }
 
         post("/deltaker/{deltakerId}/startdato") {
             val request = call.receive<StartdatoRequest>()
-            val deltakerId = UUID.fromString(call.parameters["deltakerId"])
-
-            deltakerService.upsertEndretDeltaker(deltakerId, request)
-            call.respond(HttpStatusCode.OK)
+            handleDeltakerEndring(deltakerService, request, historikkService)
         }
     }
+}
+
+private suspend fun PipelineContext<Unit, ApplicationCall>.handleDeltakerEndring(
+    deltakerService: DeltakerService,
+    request: EndringRequest,
+    historikkService: DeltakerHistorikkService,
+) {
+    val deltakerId = UUID.fromString(call.parameters["deltakerId"])
+
+    val deltaker = deltakerService.upsertEndretDeltaker(deltakerId, request)
+    val historikk = historikkService.getForDeltaker(deltaker.id)
+
+    call.respond(deltaker.toDeltakerEndringResponse(historikk))
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/DeltakerEndringResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/DeltakerEndringResponse.kt
@@ -1,0 +1,32 @@
+package no.nav.amt.deltaker.deltaker.api.model
+
+import no.nav.amt.deltaker.deltaker.model.Deltaker
+import no.nav.amt.deltaker.deltaker.model.DeltakerHistorikk
+import no.nav.amt.deltaker.deltaker.model.DeltakerStatus
+import no.nav.amt.deltaker.deltaker.model.Innhold
+import java.time.LocalDate
+import java.util.UUID
+
+data class DeltakerEndringResponse(
+    val id: UUID,
+    val startdato: LocalDate?,
+    val sluttdato: LocalDate?,
+    val dagerPerUke: Float?,
+    val deltakelsesprosent: Float?,
+    val bakgrunnsinformasjon: String?,
+    val innhold: List<Innhold>,
+    val status: DeltakerStatus,
+    val historikk: List<DeltakerHistorikk>,
+)
+
+fun Deltaker.toDeltakerEndringResponse(historikk: List<DeltakerHistorikk>) = DeltakerEndringResponse(
+    id = id,
+    startdato = startdato,
+    sluttdato = sluttdato,
+    dagerPerUke = dagerPerUke,
+    deltakelsesprosent = deltakelsesprosent,
+    bakgrunnsinformasjon = bakgrunnsinformasjon,
+    innhold = innhold,
+    status = status,
+    historikk = historikk,
+)

--- a/src/test/kotlin/no/nav/amt/deltaker/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/ApplicationTest.kt
@@ -19,7 +19,7 @@ class ApplicationTest {
         application {
             configureSerialization()
             configureAuthentication(Environment())
-            configureRouting(mockk(), mockk())
+            configureRouting(mockk(), mockk(), mockk())
         }
         client.get("/internal/health/liveness").apply {
             status shouldBe HttpStatusCode.OK

--- a/src/test/kotlin/no/nav/amt/deltaker/application/plugins/AuthenticationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/application/plugins/AuthenticationTest.kt
@@ -106,6 +106,7 @@ class AuthenticationTest {
             configureRouting(
                 mockk(),
                 mockk(),
+                mockk(),
             )
             setUpTestRoute()
         }

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/PameldingApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/PameldingApiTest.kt
@@ -131,6 +131,7 @@ class PameldingApiTest {
             configureRouting(
                 pameldingService,
                 deltakerService = mockk(),
+                mockk(),
             )
         }
     }


### PR DESCRIPTION
Siden jeg begynte å tenke på at vi kanskje må oppdatere statuser i noen av disse endringene så klarte jeg ikke å gi meg uten å se hvordan det ble seende ut å returnere en deltaker eller lignende etter endringene. Jeg skulle gjerne ønske at det holdt å få det på kafka, men jeg sitter å tviler på det hele tiden selv også. 

Jeg synes det er litt kjedelig å måtte hente ut full historikk ved vær endring, men jeg tror det er mer fremtidsrettet enn å bare returnere f.eks siste endring, for det kan fort bli til at en endring også fører med seg en vedtaksendring og da må man plutselig ha mer enn bare en ting uansett. Slik det er nå så returneres den samme informasjonen som deltaker-bffen bruker fra deltaker-v2.