### PR TITLE
endrer startdato-requesten så vi også kan angi sluttdato

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringService.kt
@@ -49,7 +49,7 @@ class DeltakerEndringService(
             }
 
             is StartdatoRequest -> {
-                val endring = DeltakerEndring.Endring.EndreStartdato(request.startdato)
+                val endring = DeltakerEndring.Endring.EndreStartdato(startdato = request.startdato, sluttdato = request.sluttdato)
                 Pair(endretDeltaker(deltaker, endring), endring)
             }
 
@@ -142,9 +142,10 @@ class DeltakerEndringService(
                 }
             }
             is DeltakerEndring.Endring.EndreStartdato -> {
-                endreDeltaker(deltaker.startdato != endring.startdato) {
+                endreDeltaker(deltaker.startdato != endring.startdato || deltaker.sluttdato != endring.sluttdato) {
                     deltaker.copy(
                         startdato = endring.startdato,
+                        sluttdato = endring.sluttdato,
                         status = if (deltaker.status.type == DeltakerStatus.Type.VENTER_PA_OPPSTART && (endring.startdato != null && !endring.startdato.isAfter(LocalDate.now()))) {
                             nyDeltakerStatus(DeltakerStatus.Type.DELTAR)
                         } else {

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
@@ -32,6 +32,7 @@ data class StartdatoRequest(
     override val endretAv: String,
     override val endretAvEnhet: String,
     val startdato: LocalDate?,
+    val sluttdato: LocalDate?,
 ) : EndringRequest
 
 data class SluttdatoRequest(

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
@@ -32,7 +32,7 @@ data class StartdatoRequest(
     override val endretAv: String,
     override val endretAvEnhet: String,
     val startdato: LocalDate?,
-    val sluttdato: LocalDate?,
+    val sluttdato: LocalDate? = null,
 ) : EndringRequest
 
 data class SluttdatoRequest(

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/DeltakerEndring.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/DeltakerEndring.kt
@@ -62,7 +62,7 @@ data class DeltakerEndring(
 
         data class EndreStartdato(
             val startdato: LocalDate?,
-            val sluttdato: LocalDate?,
+            val sluttdato: LocalDate? = null,
         ) : Endring()
 
         data class EndreSluttdato(

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/DeltakerEndring.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/DeltakerEndring.kt
@@ -62,6 +62,7 @@ data class DeltakerEndring(
 
         data class EndreStartdato(
             val startdato: LocalDate?,
+            val sluttdato: LocalDate?,
         ) : Endring()
 
         data class EndreSluttdato(

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringServiceTest.kt
@@ -161,7 +161,7 @@ class DeltakerEndringServiceTest {
 
     @Test
     fun `upsertEndring - endret startdato - upserter endring og returnerer deltaker`(): Unit = runBlocking {
-        val deltaker = TestData.lagDeltaker()
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR))
         val endretAv = TestData.lagNavAnsatt()
         val endretAvEnhet = TestData.lagNavEnhet()
 
@@ -171,14 +171,16 @@ class DeltakerEndringServiceTest {
             endretAv = endretAv.navIdent,
             endretAvEnhet = endretAvEnhet.enhetsnummer,
             startdato = LocalDate.now().minusWeeks(1),
+            sluttdato = LocalDate.now().plusWeeks(4),
         )
 
         val resultat = deltakerEndringService.upsertEndring(deltaker, endringsrequest)
 
         resultat.isSuccess shouldBe true
         val deltakerFraDb = resultat.getOrThrow()
-        deltakerFraDb.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        deltakerFraDb.status.type shouldBe DeltakerStatus.Type.DELTAR
         deltakerFraDb.startdato shouldBe endringsrequest.startdato
+        deltakerFraDb.sluttdato shouldBe endringsrequest.sluttdato
 
         val endring = deltakerEndringService.getForDeltaker(deltaker.id).first()
         endring.endretAv shouldBe endretAv.id
@@ -186,6 +188,8 @@ class DeltakerEndringServiceTest {
 
         (endring.endring as DeltakerEndring.Endring.EndreStartdato)
             .startdato shouldBe endringsrequest.startdato
+        (endring.endring as DeltakerEndring.Endring.EndreStartdato)
+            .sluttdato shouldBe endringsrequest.sluttdato
     }
 
     @Test
@@ -200,6 +204,7 @@ class DeltakerEndringServiceTest {
             endretAv = endretAv.navIdent,
             endretAvEnhet = endretAvEnhet.enhetsnummer,
             startdato = LocalDate.now().minusWeeks(1),
+            sluttdato = LocalDate.now().plusWeeks(4),
         )
 
         val resultat = deltakerEndringService.upsertEndring(deltaker, endringsrequest)
@@ -208,6 +213,7 @@ class DeltakerEndringServiceTest {
         val deltakerFraDb = resultat.getOrThrow()
         deltakerFraDb.status.type shouldBe DeltakerStatus.Type.DELTAR
         deltakerFraDb.startdato shouldBe endringsrequest.startdato
+        deltakerFraDb.sluttdato shouldBe endringsrequest.sluttdato
 
         val endring = deltakerEndringService.getForDeltaker(deltaker.id).first()
         endring.endretAv shouldBe endretAv.id
@@ -215,6 +221,8 @@ class DeltakerEndringServiceTest {
 
         (endring.endring as DeltakerEndring.Endring.EndreStartdato)
             .startdato shouldBe endringsrequest.startdato
+        (endring.endring as DeltakerEndring.Endring.EndreStartdato)
+            .sluttdato shouldBe endringsrequest.sluttdato
     }
 
     @Test

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApiTest.kt
@@ -148,7 +148,7 @@ class DeltakerApiTest {
     fun `post startdato - har tilgang - returnerer 200`() = testApplication {
         setUpTestApplication()
 
-        val endring = DeltakerEndring.Endring.EndreStartdato(LocalDate.now().minusDays(2))
+        val endring = DeltakerEndring.Endring.EndreStartdato(LocalDate.now().minusDays(2), LocalDate.now().plusMonths(2))
 
         val deltaker = TestData.lagDeltaker(startdato = endring.startdato)
         val historikk = listOf(DeltakerHistorikk.Endring(TestData.lagDeltakerEndring(endring = endring)))
@@ -162,6 +162,7 @@ class DeltakerApiTest {
                     TestData.randomIdent(),
                     TestData.randomEnhetsnummer(),
                     endring.startdato,
+                    endring.sluttdato,
                 ),
             )
         }.apply {


### PR DESCRIPTION
https://trello.com/c/RN6j61sF/1456-endre-api-for-%C3%A5-angi-oppstartsdato

Her kan vi sikkert også oppdatere statusen til har sluttet hvis man setter sluttdato tidligere enn i dag, men siden det er litt usannsynlig at man gjør det så tenker jeg vi kan la den automatiserte jobben håndtere det tilfellet (hvis de får en sluttdato tilbake i tid vil jo den sette avsluttende status). 