### PR TITLE
Bruk gjenbrukbar producer fra amt-lib

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,8 +32,6 @@ jobs:
       - name: docker-build-push
         uses: nais/docker-build-push@v0
         id: docker-build-push
-        env:
-          TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db:1"
         with:
           team: amt
           tag: ${{ github.sha }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,6 +32,8 @@ jobs:
       - name: docker-build-push
         uses: nais/docker-build-push@v0
         id: docker-build-push
+        env:
+          TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db:1"
         with:
           team: amt
           tag: ${{ github.sha }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ val postgresVersion = "42.7.4"
 val caffeineVersion = "3.1.8"
 val mockkVersion = "1.13.12"
 val nimbusVersion = "9.41.2"
-val amtLibVersion = "1.2024.10.04_10.38-b48950f1442c"
+val amtLibVersion = "1.2024.10.08_13.13-c897708cb10f"
 val unleashVersion = "9.2.4"
 val awaitilityVersion = "4.2.2"
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/forslag/kafka/ArrangorMeldingProducer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/forslag/kafka/ArrangorMeldingProducer.kt
@@ -2,32 +2,16 @@ package no.nav.amt.deltaker.deltaker.forslag.kafka
 
 import no.nav.amt.deltaker.Environment
 import no.nav.amt.deltaker.application.plugins.objectMapper
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.models.arrangor.melding.Forslag
-import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 
 class ArrangorMeldingProducer(
-    private val kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
+    private val producer: Producer<String, String>,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun produce(forslag: Forslag) {
-        val key = forslag.id.toString()
-        val value = objectMapper.writeValueAsString(forslag)
-        val record = ProducerRecord(Environment.ARRANGOR_MELDING_TOPIC, key, value)
-
-        KafkaProducer<String, String>(kafkaConfig.producerConfig()).use {
-            val metadata = it.send(record).get()
-            log.info(
-                "Produserte melding til topic ${metadata.topic()}, " +
-                    "key=$key, " +
-                    "offset=${metadata.offset()}, " +
-                    "partition=${metadata.partition()}",
-            )
-        }
+        producer.produce(Environment.ARRANGOR_MELDING_TOPIC, forslag.id.toString(), objectMapper.writeValueAsString(forslag))
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerProducer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerProducer.kt
@@ -2,48 +2,20 @@ package no.nav.amt.deltaker.deltaker.kafka
 
 import no.nav.amt.deltaker.Environment
 import no.nav.amt.deltaker.application.plugins.objectMapper
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
-import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.ProducerRecord
+import no.nav.amt.lib.kafka.Producer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class DeltakerProducer(
-    private val kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
+    private val producer: Producer<String, String>,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun produce(deltakerV2Dto: DeltakerV2Dto) {
-        val key = deltakerV2Dto.id.toString()
-        val value = objectMapper.writeValueAsString(deltakerV2Dto)
-        val record = ProducerRecord(Environment.DELTAKER_V2_TOPIC, key, value)
-
-        KafkaProducer<String, String>(kafkaConfig.producerConfig()).use {
-            val metadata = it.send(record).get()
-            log.info(
-                "Produserte melding til topic ${metadata.topic()}, " +
-                    "key=$key, " +
-                    "offset=${metadata.offset()}, " +
-                    "partition=${metadata.partition()}",
-            )
-        }
+        producer.produce(Environment.DELTAKER_V2_TOPIC, deltakerV2Dto.id.toString(), objectMapper.writeValueAsString(deltakerV2Dto))
     }
 
     fun produceTombstone(deltakerId: UUID) {
-        val key = deltakerId.toString()
-        val value: String? = null
-        val record = ProducerRecord(Environment.DELTAKER_V2_TOPIC, key, value)
-
-        KafkaProducer<String, String?>(kafkaConfig.producerConfig()).use {
-            val metadata = it.send(record).get()
-            log.info(
-                "Produserte tombstone-melding til topic ${metadata.topic()}, " +
-                    "key=$key, " +
-                    "offset=${metadata.offset()}, " +
-                    "partition=${metadata.partition()}",
-            )
-        }
+        producer.tombstone(Environment.DELTAKER_V2_TOPIC, deltakerId.toString())
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerV1Producer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerV1Producer.kt
@@ -2,48 +2,20 @@ package no.nav.amt.deltaker.deltaker.kafka
 
 import no.nav.amt.deltaker.Environment
 import no.nav.amt.deltaker.application.plugins.objectMapper
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
-import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.ProducerRecord
+import no.nav.amt.lib.kafka.Producer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class DeltakerV1Producer(
-    private val kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
+    private val producer: Producer<String, String>,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun produce(deltakerV1Dto: DeltakerV1Dto) {
-        val key = deltakerV1Dto.id.toString()
-        val value = objectMapper.writeValueAsString(deltakerV1Dto)
-        val record = ProducerRecord(Environment.DELTAKER_V1_TOPIC, key, value)
-
-        KafkaProducer<String, String>(kafkaConfig.producerConfig()).use {
-            val metadata = it.send(record).get()
-            log.info(
-                "Produserte melding til topic ${metadata.topic()}, " +
-                    "key=$key, " +
-                    "offset=${metadata.offset()}, " +
-                    "partition=${metadata.partition()}",
-            )
-        }
+        producer.produce(Environment.DELTAKER_V1_TOPIC, deltakerV1Dto.id.toString(), objectMapper.writeValueAsString(deltakerV1Dto))
     }
 
     fun produceTombstone(deltakerId: UUID) {
-        val key = deltakerId.toString()
-        val value: String? = null
-        val record = ProducerRecord(Environment.DELTAKER_V1_TOPIC, key, value)
-
-        KafkaProducer<String, String?>(kafkaConfig.producerConfig()).use {
-            val metadata = it.send(record).get()
-            log.info(
-                "Produserte tombstone-melding til topic ${metadata.topic()}, " +
-                    "key=$key, " +
-                    "offset=${metadata.offset()}, " +
-                    "partition=${metadata.partition()}",
-            )
-        }
+        producer.tombstone(Environment.DELTAKER_V1_TOPIC, deltakerId.toString())
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/hendelse/HendelseProducer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/hendelse/HendelseProducer.kt
@@ -3,31 +3,12 @@ package no.nav.amt.deltaker.hendelse
 import no.nav.amt.deltaker.Environment
 import no.nav.amt.deltaker.application.plugins.objectMapper
 import no.nav.amt.deltaker.hendelse.model.Hendelse
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
-import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.ProducerRecord
-import org.slf4j.LoggerFactory
+import no.nav.amt.lib.kafka.Producer
 
 class HendelseProducer(
-    private val kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
+    private val producer: Producer<String, String>,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     fun produce(hendelse: Hendelse) {
-        val key = hendelse.deltaker.id.toString()
-        val value = objectMapper.writeValueAsString(hendelse)
-        val record = ProducerRecord(Environment.DELTAKER_HENDELSE_TOPIC, key, value)
-
-        KafkaProducer<String, String>(kafkaConfig.producerConfig()).use {
-            val metadata = it.send(record).get()
-            log.info(
-                "Produserte melding til topic ${metadata.topic()}, " +
-                    "key=$key, " +
-                    "offset=${metadata.offset()}, " +
-                    "partition=${metadata.partition()}",
-            )
-        }
+        producer.produce(Environment.DELTAKER_HENDELSE_TOPIC, hendelse.deltaker.id.toString(), objectMapper.writeValueAsString(hendelse))
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringServiceTest.kt
@@ -36,6 +36,7 @@ import no.nav.amt.deltaker.utils.data.TestData
 import no.nav.amt.deltaker.utils.data.TestRepository
 import no.nav.amt.deltaker.utils.mockAmtArrangorClient
 import no.nav.amt.deltaker.utils.mockAmtPersonClient
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.arrangor.melding.EndringAarsak
 import no.nav.amt.lib.models.arrangor.melding.Forslag
@@ -57,6 +58,7 @@ class DeltakerEndringServiceTest {
     private val navEnhetService = NavEnhetService(NavEnhetRepository(), amtPersonClient)
     private val arrangorService = ArrangorService(ArrangorRepository(), mockAmtArrangorClient())
     private val forslagRepository = ForslagRepository()
+    private val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
     private val deltakerHistorikkService = DeltakerHistorikkService(
         DeltakerEndringRepository(),
         VedtakRepository(),
@@ -65,7 +67,7 @@ class DeltakerEndringServiceTest {
         ImportertFraArenaRepository(),
     )
     private val hendelseService = HendelseService(
-        HendelseProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+        HendelseProducer(kafkaProducer),
         navAnsattService,
         navEnhetService,
         arrangorService,
@@ -73,7 +75,7 @@ class DeltakerEndringServiceTest {
     )
     private val forslagService = ForslagService(
         forslagRepository,
-        ArrangorMeldingProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+        ArrangorMeldingProducer(kafkaProducer),
         DeltakerRepository(),
         mockk(),
     )

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerServiceTest.kt
@@ -39,6 +39,7 @@ import no.nav.amt.deltaker.utils.data.TestData
 import no.nav.amt.deltaker.utils.data.TestRepository
 import no.nav.amt.deltaker.utils.mockAmtArrangorClient
 import no.nav.amt.deltaker.utils.mockAmtPersonClient
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltaker.DeltakerEndring
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
@@ -64,6 +65,7 @@ class DeltakerServiceTest {
         private val endringFraArrangorRepository = EndringFraArrangorRepository()
         private val arrangorService = ArrangorService(ArrangorRepository(), mockAmtArrangorClient())
         private val importertFraArenaRepository = ImportertFraArenaRepository()
+        private val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
         private val deltakerHistorikkService =
             DeltakerHistorikkService(
                 deltakerEndringRepository,
@@ -73,7 +75,7 @@ class DeltakerServiceTest {
                 importertFraArenaRepository,
             )
         private val hendelseService = HendelseService(
-            HendelseProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+            HendelseProducer(kafkaProducer),
             navAnsattService,
             navEnhetService,
             arrangorService,
@@ -83,16 +85,16 @@ class DeltakerServiceTest {
         private val deltakerV2MapperService =
             DeltakerV2MapperService(navAnsattService, navEnhetService, deltakerHistorikkService)
         private val deltakerProducer = DeltakerProducer(
-            LocalKafkaConfig(SingletonKafkaProvider.getHost()),
+            kafkaProducer,
         )
         private val deltakerV1Producer = DeltakerV1Producer(
-            LocalKafkaConfig(SingletonKafkaProvider.getHost()),
+            kafkaProducer,
         )
         private val deltakerProducerService =
             DeltakerProducerService(deltakerV2MapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
         private val forslagService = ForslagService(
             forslagRepository,
-            ArrangorMeldingProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+            ArrangorMeldingProducer(kafkaProducer),
             deltakerRepository,
             deltakerProducerService,
         )

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
@@ -34,6 +34,7 @@ import no.nav.amt.deltaker.utils.data.TestData
 import no.nav.amt.deltaker.utils.data.TestRepository
 import no.nav.amt.deltaker.utils.mockAmtArrangorClient
 import no.nav.amt.deltaker.utils.mockAmtPersonClient
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
@@ -58,6 +59,7 @@ class PameldingServiceTest {
         private val endringFraArrangorRepository = EndringFraArrangorRepository()
         private val vedtakRepository = VedtakRepository()
         private val importertFraArenaRepository = ImportertFraArenaRepository()
+        private val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
         private val deltakerHistorikkService =
             DeltakerHistorikkService(
                 deltakerEndringRepository,
@@ -67,7 +69,7 @@ class PameldingServiceTest {
                 importertFraArenaRepository,
             )
         private val hendelseService = HendelseService(
-            HendelseProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+            HendelseProducer(kafkaProducer),
             navAnsattService,
             navEnhetService,
             arrangorService,

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/VedtakServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.amt.deltaker.utils.data.TestData
 import no.nav.amt.deltaker.utils.data.TestRepository
 import no.nav.amt.deltaker.utils.mockAmtArrangorClient
 import no.nav.amt.deltaker.utils.mockAmtPersonClient
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltaker.Vedtak
 import no.nav.amt.lib.testing.SingletonKafkaProvider
@@ -47,8 +48,9 @@ class VedtakServiceTest {
             EndringFraArrangorRepository(),
             ImportertFraArenaRepository(),
         )
+    private val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
     private val hendelseService = HendelseService(
-        HendelseProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+        HendelseProducer(kafkaProducer),
         navAnsattService,
         navEnhetService,
         arrangorService,

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.amt.deltaker.utils.data.TestData
 import no.nav.amt.deltaker.utils.data.TestRepository
 import no.nav.amt.deltaker.utils.mockAmtArrangorClient
 import no.nav.amt.deltaker.utils.mockAmtPersonClient
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.arrangor.melding.EndringFraArrangor
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
@@ -48,8 +49,9 @@ class EndringFraArrangorServiceTest {
         endringFraArrangorRepository,
         ImportertFraArenaRepository(),
     )
+    private val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
     private val hendelseService = HendelseService(
-        HendelseProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+        HendelseProducer(kafkaProducer),
         navAnsattService,
         navEnhetService,
         arrangorService,

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumerTest.kt
@@ -31,6 +31,7 @@ import no.nav.amt.deltaker.utils.data.TestData.lagNavBruker
 import no.nav.amt.deltaker.utils.data.TestData.lagTiltakstype
 import no.nav.amt.deltaker.utils.data.TestData.toDeltakerV2
 import no.nav.amt.deltaker.utils.data.TestRepository
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
@@ -73,6 +74,7 @@ class DeltakerConsumerTest {
         @BeforeClass
         fun setup() {
             SingletonPostgres16Container
+            val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
             deltakerRepository = DeltakerRepository()
             importertFraArenaRepository = ImportertFraArenaRepository()
             deltakerlisteRepository = DeltakerlisteRepository()
@@ -95,9 +97,7 @@ class DeltakerConsumerTest {
             )
             deltakerEndringService = mockk()
             deltakerV2MapperService = DeltakerV2MapperService(navAnsattService, navEnhetService, deltakerHistorikkService)
-            deltakerProducer = DeltakerProducer(
-                LocalKafkaConfig(SingletonKafkaProvider.getHost()),
-            )
+            deltakerProducer = DeltakerProducer(kafkaProducer)
             deltakerV1Producer = mockk(relaxed = true)
             deltakerProducerService = DeltakerProducerService(deltakerV2MapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
             consumer = DeltakerConsumer(

--- a/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringServiceTest.kt
@@ -35,6 +35,7 @@ import no.nav.amt.deltaker.utils.data.TestData
 import no.nav.amt.deltaker.utils.data.TestRepository
 import no.nav.amt.deltaker.utils.mockAmtArrangorClient
 import no.nav.amt.deltaker.utils.mockAmtPersonClient
+import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import no.nav.amt.lib.testing.SingletonKafkaProvider
@@ -58,6 +59,7 @@ class DeltakerStatusOppdateringServiceTest {
         private val forslagRepository = ForslagRepository()
         private val endringFraArrangorRepository = EndringFraArrangorRepository()
         private val importertFraArenaRepository = ImportertFraArenaRepository()
+        private val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
         private val deltakerHistorikkService =
             DeltakerHistorikkService(
                 deltakerEndringRepository,
@@ -68,13 +70,13 @@ class DeltakerStatusOppdateringServiceTest {
             )
         private val unleashToggle = mockk<UnleashToggle>()
         private val deltakerV2MapperService = DeltakerV2MapperService(navAnsattService, navEnhetService, deltakerHistorikkService)
-        private val deltakerProducer = DeltakerProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
-        private val deltakerV1Producer = DeltakerV1Producer(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
+        private val deltakerProducer = DeltakerProducer(kafkaProducer)
+        private val deltakerV1Producer = DeltakerV1Producer(kafkaProducer)
         private val deltakerProducerService =
             DeltakerProducerService(deltakerV2MapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
         private val arrangorService = ArrangorService(ArrangorRepository(), mockAmtArrangorClient())
         private val hendelseService = HendelseService(
-            HendelseProducer(LocalKafkaConfig(SingletonKafkaProvider.getHost())),
+            HendelseProducer(kafkaProducer),
             navAnsattService,
             navEnhetService,
             arrangorService,


### PR DESCRIPTION
Hvis man stenger produseren etter hver sending så tar det fort 100ms per record sendt. Hvis man gjenbruker den så tar det kanskje 5-10ms per record. Siden vi ofte sender meldinger på flere topics for vær endring som skjer så medførte dette at responstiden ble veldig trege, en deltakerendring tar ofte mellom 500-700ms å utføre på `main` nå, med denne PRen så ligger de på rundt 250ms. 

Ved å ikke lukke produseren så risikerer man at ressurser lekker, men jeg tror ikke det er noe særlig farlig. Produserne våre som bruker fellesbiblioteket i dag stenges eller ikke og vi har ikke lagt merke til noe trøbbel der.