### PR TITLE
endrer toggle så vi alltid er master for AFT

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
@@ -6,7 +6,15 @@ import no.nav.amt.deltaker.deltakerliste.tiltakstype.Tiltakstype
 class UnleashToggle(
     private val unleashClient: Unleash,
 ) {
+    private val tiltakstyperKometAlltidErMasterFor = listOf(
+        Tiltakstype.ArenaKode.ARBFORB,
+    )
+
+    // her kan vi legge inn de neste tiltakstypene vi skal ta over
+    private val tiltakstyperKometKanskjeErMasterFor = emptyList<Tiltakstype.ArenaKode>()
+
     fun erKometMasterForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean {
-        return unleashClient.isEnabled("amt.enable-komet-deltakere") && tiltakstype == Tiltakstype.ArenaKode.ARBFORB
+        return tiltakstype in tiltakstyperKometAlltidErMasterFor ||
+            (unleashClient.isEnabled("amt.enable-komet-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
     }
 }


### PR DESCRIPTION
https://trello.com/c/2jW2Jep2/1803-etter-lansering-endre-i-appene-som-sjekker-om-komet-er-master-for-deltakere-slik-at-komet-alltid-er-master-for-aft