### PR TITLE
Støtte innlesing av nye tiltakstyper og at innlesingen kan skje før eksponering av data til valp

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/Application.kt
@@ -227,6 +227,7 @@ fun Application.module() {
             deltakerEndringService,
             importertFraArenaRepository,
             deltakerProducerService,
+            unleashToggle,
         ),
         ArrangorMeldingConsumer(forslagService, deltakerService),
     )

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/HentDeltakelserApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/HentDeltakelserApi.kt
@@ -18,6 +18,7 @@ fun Routing.registerHentDeltakelserApi(
     deltakelserResponseMapper: DeltakelserResponseMapper,
     unleashToggle: UnleashToggle,
 ) {
+    // API til valp hvor de henter ut alle deltakelser til person
     authenticate("VEILEDER") {
         post("/deltakelser") {
             val request = call.receive<DeltakelserRequest>()

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumer.kt
@@ -10,8 +10,8 @@ import no.nav.amt.deltaker.deltaker.model.Deltaker
 import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.deltakerliste.DeltakerlisteRepository
-import no.nav.amt.deltaker.deltakerliste.tiltakstype.Tiltakstype
 import no.nav.amt.deltaker.navbruker.NavBrukerService
+import no.nav.amt.deltaker.unleash.UnleashToggle
 import no.nav.amt.lib.kafka.Consumer
 import no.nav.amt.lib.kafka.ManagedKafkaConsumer
 import no.nav.amt.lib.kafka.config.KafkaConfig
@@ -34,6 +34,7 @@ class DeltakerConsumer(
     private val deltakerEndringService: DeltakerEndringService,
     private val importertFraArenaRepository: ImportertFraArenaRepository,
     private val deltakerProducerService: DeltakerProducerService,
+    private val unleashToggle: UnleashToggle,
     kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl("earliest"),
 ) : Consumer<UUID, String?> {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -70,7 +71,7 @@ class DeltakerConsumer(
             return
         }
 
-        if (deltakerliste.tiltakstype.arenaKode == Tiltakstype.ArenaKode.ARBFORB) {
+        if (unleashToggle.skalLeseArenaDeltakereForTiltakstype(deltakerliste.tiltakstype.arenaKode)) {
             log.info("Ingester arenadeltaker med id ${deltakerV2.id}")
             val deltaker = deltakerV2.toDeltaker(deltakerliste)
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumer.kt
@@ -61,12 +61,15 @@ class DeltakerConsumer(
 
     private suspend fun processDeltaker(deltakerV2: DeltakerV2Dto) {
         val deltakerliste = deltakerlisteRepository.get(deltakerV2.deltakerlisteId).getOrThrow()
-        if (deltakerV2.kilde == Kilde.KOMET) {
+        val opprettetAvKomet = deltakerV2.kilde == Kilde.KOMET
+        val deltakerLestInnTidligere = deltakerV2.historikk != null
+
+        if (opprettetAvKomet) {
             log.info("Hopper over komet deltaker på deltaker-v2. deltakerId: ${deltakerV2.id}")
             return
         }
 
-        if (deltakerV2.historikk != null) {
+        if (deltakerLestInnTidligere) {
             log.info("Hopper over deltaker med id ${deltakerV2.id} fordi deltakeren er allerede bearbeidet")
             return
         }

--- a/src/main/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringService.kt
@@ -25,7 +25,8 @@ class DeltakerStatusOppdateringService(
     }
 
     suspend fun avsluttDeltakelserForAvbruttDeltakerliste(deltakerlisteId: UUID) {
-        val deltakerePaAvbruttDeltakerliste = deltakerService.getDeltakereForDeltakerliste(deltakerlisteId)
+        val deltakerePaAvbruttDeltakerliste = deltakerService
+            .getDeltakereForDeltakerliste(deltakerlisteId)
             .filter { it.status.type != DeltakerStatus.Type.KLADD }
 
         oppdaterTilAvsluttendeStatus(deltakerePaAvbruttDeltakerliste)

--- a/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
@@ -17,13 +17,9 @@ class UnleashToggle(
         Tiltakstype.ArenaKode.ARBRRHDAG,
     )
 
-    fun erKometMasterForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean {
-        return tiltakstype in tiltakstyperKometErMasterFor ||
-            (unleashClient.isEnabled("amt.enable-komet-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
-    }
+    fun erKometMasterForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean = tiltakstype in tiltakstyperKometErMasterFor ||
+        (unleashClient.isEnabled("amt.enable-komet-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
 
-    fun skalLeseArenaDeltakereForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean {
-        return tiltakstype in tiltakstyperKometErMasterFor ||
-            (unleashClient.isEnabled("amt.les-arena-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
-    }
+    fun skalLeseArenaDeltakereForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean =
+        unleashClient.isEnabled("amt.les-arena-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
@@ -6,15 +6,24 @@ import no.nav.amt.deltaker.deltakerliste.tiltakstype.Tiltakstype
 class UnleashToggle(
     private val unleashClient: Unleash,
 ) {
-    private val tiltakstyperKometAlltidErMasterFor = listOf(
+    private val tiltakstyperKometErMasterFor = listOf(
         Tiltakstype.ArenaKode.ARBFORB,
     )
 
     // her kan vi legge inn de neste tiltakstypene vi skal ta over
-    private val tiltakstyperKometKanskjeErMasterFor = emptyList<Tiltakstype.ArenaKode>()
+    private val tiltakstyperKometKanskjeErMasterFor = listOf(
+        Tiltakstype.ArenaKode.INDOPPFAG,
+        Tiltakstype.ArenaKode.AVKLARAG,
+        Tiltakstype.ArenaKode.ARBRRHDAG
+    )
 
     fun erKometMasterForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean {
-        return tiltakstype in tiltakstyperKometAlltidErMasterFor ||
+        return tiltakstype in tiltakstyperKometErMasterFor ||
             (unleashClient.isEnabled("amt.enable-komet-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
+    }
+
+    fun skalLeseArenaDeltakereForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean {
+        return tiltakstype in tiltakstyperKometErMasterFor ||
+                (unleashClient.isEnabled("amt.les-arena-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/unleash/UnleashToggle.kt
@@ -14,7 +14,7 @@ class UnleashToggle(
     private val tiltakstyperKometKanskjeErMasterFor = listOf(
         Tiltakstype.ArenaKode.INDOPPFAG,
         Tiltakstype.ArenaKode.AVKLARAG,
-        Tiltakstype.ArenaKode.ARBRRHDAG
+        Tiltakstype.ArenaKode.ARBRRHDAG,
     )
 
     fun erKometMasterForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean {
@@ -24,6 +24,6 @@ class UnleashToggle(
 
     fun skalLeseArenaDeltakereForTiltakstype(tiltakstype: Tiltakstype.ArenaKode): Boolean {
         return tiltakstype in tiltakstyperKometErMasterFor ||
-                (unleashClient.isEnabled("amt.les-arena-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
+            (unleashClient.isEnabled("amt.les-arena-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumerTest.kt
@@ -107,6 +107,7 @@ class DeltakerConsumerTest {
                 deltakerEndringService,
                 importertFraArenaRepository,
                 deltakerProducerService,
+                unleashToggle,
             )
         }
     }
@@ -242,6 +243,7 @@ class DeltakerConsumerTest {
         every { vedtakRepository.getForDeltaker(deltaker.id) } returns emptyList()
         every { forslagRepository.getForDeltaker(deltaker.id) } returns emptyList()
         every { endringFraArrangorRepository.getForDeltaker(deltaker.id) } returns emptyList()
+        every { unleashToggle.skalLeseArenaDeltakereForTiltakstype(deltakerliste.tiltakstype.arenaKode) } returns true
 
         val deltakerV2Dto = oppdatertDeltaker.toDeltakerV2(innsoktDato = innsoktDato)
 


### PR DESCRIPTION
https://trello.com/c/XOyqiyH6/1892-laste-arenadata-for-avklaring-arr-oppf%C3%B8lging-inn-i-verdikjeden