### PR TITLE
Endre deltakelsesmengde når startdato endres

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ val caffeineVersion = "3.1.8"
 val mockkVersion = "1.13.13"
 val nimbusVersion = "9.47"
 val unleashVersion = "9.2.6"
-val amtLibVersion = "1.2024.11.29_13.21-0b13fe19f0e7"
+val amtLibVersion = "1.2024.11.29_14.46-561c9bf2385c"
 val awaitilityVersion = "4.2.2"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,8 @@ val postgresVersion = "42.7.4"
 val caffeineVersion = "3.1.8"
 val mockkVersion = "1.13.13"
 val nimbusVersion = "9.47"
-val amtLibVersion = "1.2024.11.21_05.47-140eeb3c0bfa"
 val unleashVersion = "9.2.6"
+val amtLibVersion = "1.2024.11.29_13.21-0b13fe19f0e7"
 val awaitilityVersion = "4.2.2"
 
 dependencies {

--- a/src/main/kotlin/no/nav/amt/deltaker/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/Application.kt
@@ -207,7 +207,7 @@ fun Application.module() {
         )
     val deltakelserResponseMapper = DeltakelserResponseMapper(deltakerHistorikkService, arrangorService)
 
-    val endringFraArrangorService = EndringFraArrangorService(endringFraArrangorRepository, hendelseService)
+    val endringFraArrangorService = EndringFraArrangorService(endringFraArrangorRepository, hendelseService, deltakerHistorikkService)
     val vedtakService = VedtakService(vedtakRepository, hendelseService)
     val deltakerService = DeltakerService(
         deltakerRepository = deltakerRepository,

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
@@ -6,6 +6,7 @@ import no.nav.amt.deltaker.deltaker.nyDeltakerStatus
 import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
 import no.nav.amt.lib.models.deltaker.DeltakerEndring
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltaker.deltakelsesmengde.Deltakelsesmengder
 import no.nav.amt.lib.models.deltaker.deltakelsesmengde.toDeltakelsesmengde
 import no.nav.amt.lib.models.deltaker.deltakelsesmengde.toDeltakelsesmengder
 import java.time.LocalDate
@@ -64,14 +65,11 @@ class DeltakerEndringHandler(
 
     private fun endreStartdato(endring: DeltakerEndring.Endring.EndreStartdato) =
         endreDeltaker(deltaker.startdato != endring.startdato || deltaker.sluttdato != endring.sluttdato) {
-            val oppdatertStatus = deltaker.getStatusEndretStartOgSluttdato(
-                startdato = endring.startdato,
-                sluttdato = endring.sluttdato,
-            )
-            deltaker.copy(
-                startdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else endring.startdato,
-                sluttdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else endring.sluttdato,
-                status = oppdatertStatus,
+            endreDeltakersOppstart(
+                deltaker,
+                endring.startdato,
+                endring.sluttdato,
+                deltakerHistorikkService.getForDeltaker(deltaker.id).toDeltakelsesmengder(),
             )
         }
 
@@ -146,4 +144,26 @@ class DeltakerEndringHandler(
         } else {
             status
         }
+}
+
+fun endreDeltakersOppstart(
+    deltaker: Deltaker,
+    startdato: LocalDate?,
+    sluttdato: LocalDate?,
+    deltakelsesmengder: Deltakelsesmengder,
+): Deltaker {
+    val oppdatertStatus = deltaker.getStatusEndretStartOgSluttdato(
+        startdato = startdato,
+        sluttdato = sluttdato,
+    )
+    val oppdatertDeltakelsmengde = deltakelsesmengder.avgrensPeriodeTilStartdato(startdato)
+    val gjeldendeEllerNesteDeltakelsesmengde = oppdatertDeltakelsmengde.gjeldende ?: oppdatertDeltakelsmengde.nesteGjeldende
+
+    return deltaker.copy(
+        startdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else startdato,
+        sluttdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else sluttdato,
+        status = oppdatertStatus,
+        deltakelsesprosent = gjeldendeEllerNesteDeltakelsesmengde?.deltakelsesprosent,
+        dagerPerUke = gjeldendeEllerNesteDeltakelsesmengde?.dagerPerUke,
+    )
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
@@ -157,13 +157,12 @@ fun endreDeltakersOppstart(
         sluttdato = sluttdato,
     )
     val oppdatertDeltakelsmengde = deltakelsesmengder.avgrensPeriodeTilStartdato(startdato)
-    val gjeldendeEllerNesteDeltakelsesmengde = oppdatertDeltakelsmengde.gjeldende ?: oppdatertDeltakelsmengde.nesteGjeldende
 
     return deltaker.copy(
         startdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else startdato,
         sluttdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else sluttdato,
         status = oppdatertStatus,
-        deltakelsesprosent = gjeldendeEllerNesteDeltakelsesmengde?.deltakelsesprosent,
-        dagerPerUke = gjeldendeEllerNesteDeltakelsesmengde?.dagerPerUke,
+        deltakelsesprosent = oppdatertDeltakelsmengde.gjeldende?.deltakelsesprosent,
+        dagerPerUke = oppdatertDeltakelsmengde.gjeldende?.dagerPerUke,
     )
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringService.kt
@@ -75,16 +75,20 @@ class DeltakerEndringService(
 
         val gyldigeDeltakelsesmengder = deltakerHistorikkService.getForDeltaker(deltaker.id).toDeltakelsesmengder()
 
-        val utfall = if (deltakelsesmengde == gyldigeDeltakelsesmengder.gjeldende) {
-            DeltakerEndringUtfall.VellykketEndring(
-                deltaker.copy(
-                    deltakelsesprosent = deltakelsesmengde.deltakelsesprosent,
-                    dagerPerUke = deltakelsesmengde.dagerPerUke,
-                ),
-            )
-        } else {
-            DeltakerEndringUtfall.UgyldigEndring(IllegalStateException("Endringen er ikke lenger gyldig"))
-        }
+        val endringenErIkkeUtfort = deltaker.deltakelsesprosent != deltakelsesmengde.deltakelsesprosent ||
+            deltaker.dagerPerUke != deltakelsesmengde.dagerPerUke
+
+        val utfall =
+            if (deltakelsesmengde == gyldigeDeltakelsesmengder.gjeldende && endringenErIkkeUtfort) {
+                DeltakerEndringUtfall.VellykketEndring(
+                    deltaker.copy(
+                        deltakelsesprosent = deltakelsesmengde.deltakelsesprosent,
+                        dagerPerUke = deltakelsesmengde.dagerPerUke,
+                    ),
+                )
+            } else {
+                DeltakerEndringUtfall.UgyldigEndring(IllegalStateException("Endringen er ikke lenger gyldig"))
+            }
 
         log.info("Behandler endring: ${endring.id}, utfall: ${utfall::class.simpleName}, deltaker: ${deltaker.id}")
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorService.kt
@@ -5,9 +5,8 @@ import no.nav.amt.deltaker.deltaker.endring.endreDeltakersOppstart
 import no.nav.amt.deltaker.deltaker.model.Deltaker
 import no.nav.amt.deltaker.hendelse.HendelseService
 import no.nav.amt.lib.models.arrangor.melding.EndringFraArrangor
-import no.nav.amt.lib.models.deltaker.DeltakerStatus
-import org.slf4j.LoggerFactory
 import no.nav.amt.lib.models.deltaker.deltakelsesmengde.toDeltakelsesmengder
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class EndringFraArrangorService(

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerEndringServiceTest.kt
@@ -46,6 +46,7 @@ import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
 import no.nav.amt.lib.models.deltaker.DeltakerEndring
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import no.nav.amt.lib.models.deltaker.Innhold
+import no.nav.amt.lib.models.deltaker.deltakelsesmengde.toDeltakelsesmengder
 import no.nav.amt.lib.testing.SingletonKafkaProvider
 import no.nav.amt.lib.testing.SingletonPostgres16Container
 import org.junit.Before
@@ -905,6 +906,62 @@ class DeltakerEndringServiceTest {
 
         ubehandlete.size shouldBe 1
         sammenlignDeltakerEndring(ubehandlete.first(), gyldigEndring)
+    }
+
+    @Test
+    fun `behandleLagretEndring - endringen er utført pga endret startdato - oppdaterer ikke deltaker og upserter endring med behandlet`() {
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR))
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val vedtak = TestData.lagVedtak(
+            deltakerVedVedtak = deltaker,
+            opprettetAv = endretAv,
+            opprettetAvEnhet = endretAvEnhet,
+            fattet = LocalDateTime.now().minusWeeks(2),
+        )
+
+        val startdato = LocalDate.now().plusWeeks(1)
+
+        val startdatoEndring = TestData.lagDeltakerEndring(
+            deltakerId = deltaker.id,
+            endretAv = endretAv.id,
+            endretAvEnhet = endretAvEnhet.id,
+            endring = DeltakerEndring.Endring.EndreStartdato(
+                startdato = startdato,
+                sluttdato = null,
+                begrunnelse = null,
+            ),
+            endret = LocalDateTime.now().minusMinutes(2),
+        )
+
+        TestRepository.insertAll(deltaker, endretAv, endretAvEnhet, vedtak, startdatoEndring)
+
+        val fremtidigEndring = upsertEndring(
+            TestData.lagDeltakerEndring(
+                deltakerId = deltaker.id,
+                endretAv = endretAv.id,
+                endretAvEnhet = endretAvEnhet.id,
+                endring = DeltakerEndring.Endring.EndreDeltakelsesmengde(
+                    deltakelsesprosent = 90F,
+                    dagerPerUke = null,
+                    gyldigFra = startdato,
+                    begrunnelse = "begrunnelse",
+                ),
+                endret = LocalDateTime.now().minusSeconds(2),
+            ),
+            null,
+        )
+
+        val resultat = deltakerEndringService.behandleLagretDeltakelsesmengde(fremtidigEndring, deltaker)
+        resultat.erUgyldig shouldBe true
+
+        val ubehandlete = deltakerEndringRepository.getUbehandletDeltakelsesmengder()
+        ubehandlete.size shouldBe 0
+
+        val deltakelsesmengder = deltakerHistorikkService.getForDeltaker(deltaker.id).toDeltakelsesmengder()
+        deltakelsesmengder.size shouldBe 1
+        deltakelsesmengder.gjeldende shouldBe null
+        deltakelsesmengder.nesteGjeldende!!.gyldigFra shouldBe startdato
     }
 
     private fun upsertEndring(endring: DeltakerEndring, behandlet: LocalDateTime? = null): DeltakerEndring {

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerServiceTest.kt
@@ -109,7 +109,11 @@ class DeltakerServiceTest {
                 forslagService,
                 deltakerHistorikkService,
             )
-        private val endringFraArrangorService = EndringFraArrangorService(endringFraArrangorRepository, hendelseService)
+        private val endringFraArrangorService = EndringFraArrangorService(
+            endringFraArrangorRepository = endringFraArrangorRepository,
+            hendelseService = hendelseService,
+            deltakerHistorikkService = deltakerHistorikkService,
+        )
 
         private val deltakerService = DeltakerService(
             deltakerRepository = deltakerRepository,

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
@@ -84,7 +84,11 @@ class PameldingServiceTest {
 
         private val vedtakService = VedtakService(vedtakRepository, hendelseService)
         private val forslagService = ForslagService(forslagRepository, mockk(), deltakerRepository, mockk())
-        private val endringFraArrangorService = EndringFraArrangorService(endringFraArrangorRepository, hendelseService)
+        private val endringFraArrangorService = EndringFraArrangorService(
+            endringFraArrangorRepository = endringFraArrangorRepository,
+            hendelseService = hendelseService,
+            deltakerHistorikkService = deltakerHistorikkService,
+        )
 
         private val deltakerService = DeltakerService(
             deltakerRepository = deltakerRepository,

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
@@ -1,0 +1,119 @@
+package no.nav.amt.deltaker.deltaker.endring
+
+import io.kotest.matchers.shouldBe
+import no.nav.amt.deltaker.utils.data.TestData
+import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltaker.deltakelsesmengde.Deltakelsesmengde
+import no.nav.amt.lib.models.deltaker.deltakelsesmengde.Deltakelsesmengder
+import org.junit.Test
+import java.time.LocalDate
+
+class DeltakerEndringHandlerTest {
+    @Test
+    fun `endreDeltakersOppstart - fremtidig startdato - endrer også deltakelsesmengde`() {
+        val nyStartdato = LocalDate.now().plusMonths(1)
+        val gammelStartdato = nyStartdato.minusMonths(1)
+
+        val gjeldendeMengde = Deltakelsesmengde(
+            deltakelsesprosent = 100F,
+            dagerPerUke = null,
+            gyldigFra = gammelStartdato,
+            opprettet = gammelStartdato.atStartOfDay(),
+        )
+        val fremtidigMengde = Deltakelsesmengde(
+            deltakelsesprosent = 42F,
+            dagerPerUke = 2F,
+            gyldigFra = nyStartdato,
+            opprettet = nyStartdato.atStartOfDay(),
+        )
+
+        val gammelDeltakelsesmengder = Deltakelsesmengder(
+            listOf(gjeldendeMengde, fremtidigMengde),
+        )
+
+        val deltaker = TestData.lagDeltaker(
+            startdato = gammelStartdato,
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            dagerPerUke = gjeldendeMengde.dagerPerUke,
+            deltakelsesprosent = gjeldendeMengde.deltakelsesprosent,
+        )
+
+        val endretDeltaker = endreDeltakersOppstart(deltaker, nyStartdato, null, gammelDeltakelsesmengder)
+
+        endretDeltaker.startdato shouldBe nyStartdato
+        endretDeltaker.dagerPerUke shouldBe fremtidigMengde.dagerPerUke
+        endretDeltaker.deltakelsesprosent shouldBe fremtidigMengde.deltakelsesprosent
+    }
+
+    @Test
+    fun `endreDeltakersOppstart - null startdato - endrer ikke deltakelsesmengde`() {
+        val nyStartdato = null
+        val gammelStartdato = LocalDate.now().minusMonths(1)
+
+        val gjeldendeMengde = Deltakelsesmengde(
+            deltakelsesprosent = 100F,
+            dagerPerUke = null,
+            gyldigFra = gammelStartdato,
+            opprettet = gammelStartdato.atStartOfDay(),
+        )
+        val fremtidigMengde = Deltakelsesmengde(
+            deltakelsesprosent = 42F,
+            dagerPerUke = 2F,
+            gyldigFra = gammelStartdato.plusMonths(2),
+            opprettet = gammelStartdato.plusMonths(2).atStartOfDay(),
+        )
+
+        val gammelDeltakelsesmengder = Deltakelsesmengder(
+            listOf(gjeldendeMengde, fremtidigMengde),
+        )
+
+        val deltaker = TestData.lagDeltaker(
+            startdato = gammelStartdato,
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            dagerPerUke = gjeldendeMengde.dagerPerUke,
+            deltakelsesprosent = gjeldendeMengde.deltakelsesprosent,
+        )
+
+        val endretDeltaker = endreDeltakersOppstart(deltaker, nyStartdato, null, gammelDeltakelsesmengder)
+
+        endretDeltaker.startdato shouldBe nyStartdato
+        endretDeltaker.dagerPerUke shouldBe gjeldendeMengde.dagerPerUke
+        endretDeltaker.deltakelsesprosent shouldBe gjeldendeMengde.deltakelsesprosent
+    }
+
+    @Test
+    fun `endreDeltakersOppstart - eldre startdato - endrer ikke deltakelsesmengde`() {
+        val gammelStartdato = LocalDate.now().minusMonths(1)
+        val nyStartdato = gammelStartdato.minusMonths(1)
+
+        val gjeldendeMengde = Deltakelsesmengde(
+            deltakelsesprosent = 100F,
+            dagerPerUke = null,
+            gyldigFra = gammelStartdato,
+            opprettet = gammelStartdato.atStartOfDay(),
+        )
+        val fremtidigMengde = Deltakelsesmengde(
+            deltakelsesprosent = 42F,
+            dagerPerUke = 2F,
+            gyldigFra = gammelStartdato.plusMonths(2),
+            opprettet = gammelStartdato.plusMonths(2).atStartOfDay(),
+        )
+
+        val gammelDeltakelsesmengder = Deltakelsesmengder(
+            listOf(gjeldendeMengde, fremtidigMengde),
+        )
+
+        val deltaker = TestData.lagDeltaker(
+            startdato = gammelStartdato,
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            dagerPerUke = gjeldendeMengde.dagerPerUke,
+            deltakelsesprosent = gjeldendeMengde.deltakelsesprosent,
+        )
+
+        val endretDeltaker = endreDeltakersOppstart(deltaker, nyStartdato, null, gammelDeltakelsesmengder)
+
+        endretDeltaker.startdato shouldBe nyStartdato
+        endretDeltaker.dagerPerUke shouldBe gjeldendeMengde.dagerPerUke
+        endretDeltaker.deltakelsesprosent shouldBe gjeldendeMengde.deltakelsesprosent
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorServiceTest.kt
@@ -57,7 +57,11 @@ class EndringFraArrangorServiceTest {
         arrangorService,
         deltakerHistorikkService,
     )
-    private val endringFraArrangorService = EndringFraArrangorService(endringFraArrangorRepository, hendelseService)
+    private val endringFraArrangorService = EndringFraArrangorService(
+        endringFraArrangorRepository = endringFraArrangorRepository,
+        hendelseService = hendelseService,
+        deltakerHistorikkService = deltakerHistorikkService,
+    )
 
     companion object {
         @JvmStatic

--- a/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringServiceTest.kt
@@ -93,7 +93,11 @@ class DeltakerStatusOppdateringServiceTest {
             deltakerHistorikkService = deltakerHistorikkService,
         )
         private val vedtakService = VedtakService(vedtakRepository, hendelseService)
-        private val endringFraArrangorService = EndringFraArrangorService(endringFraArrangorRepository, hendelseService)
+        private val endringFraArrangorService = EndringFraArrangorService(
+            endringFraArrangorRepository = endringFraArrangorRepository,
+            hendelseService = hendelseService,
+            deltakerHistorikkService = deltakerHistorikkService,
+        )
 
         @JvmStatic
         @BeforeClass

--- a/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
@@ -309,7 +309,7 @@ object TestData {
         fattet: LocalDateTime? = null,
         gyldigTil: LocalDateTime? = null,
         fattetAvNav: Boolean = false,
-        opprettet: LocalDateTime = LocalDateTime.now(),
+        opprettet: LocalDateTime = fattet ?: LocalDateTime.now(),
         opprettetAv: NavAnsatt = lagNavAnsatt(),
         opprettetAvEnhet: NavEnhet = lagNavEnhet(),
         sistEndret: LocalDateTime = opprettet,


### PR DESCRIPTION
Når startdato endres, må deltakelsesmengdene også rekalkuleres for å sette riktig mengde i selve deltakerobjektet. Det er mye som skjer når man endrer startdato nå...

Det er litt kjipt å vedlikeholde den gjeldende deltakelsesmengden på deltakeren på denne måten. Det hadde nok vært lurt å refaktorere seg bort i fra å bruke de i det hele tatt, men det er en større jobb som krever at man håndterer kladd litt annerledes også er det litt kjedelig å måtte hente ut en liste med enten historikk eller deltakelsesmengder hver gang man skal ha en deltaker.