### PR TITLE
Dersom sluttdato ikke er oppgitt i EndreOppstart endring så skal ikke deltakers sluttdato nullstilles

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
@@ -152,15 +152,16 @@ fun endreDeltakersOppstart(
     sluttdato: LocalDate?,
     deltakelsesmengder: Deltakelsesmengder,
 ): Deltaker {
+    val faktiskSluttdato = sluttdato ?: deltaker.sluttdato
     val oppdatertStatus = deltaker.getStatusEndretStartOgSluttdato(
         startdato = startdato,
-        sluttdato = sluttdato,
+        sluttdato = faktiskSluttdato,
     )
     val oppdatertDeltakelsmengde = deltakelsesmengder.avgrensPeriodeTilStartdato(startdato)
 
     return deltaker.copy(
         startdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else startdato,
-        sluttdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else sluttdato,
+        sluttdato = if (oppdatertStatus.type == DeltakerStatus.Type.IKKE_AKTUELL) null else faktiskSluttdato,
         status = oppdatertStatus,
         deltakelsesprosent = oppdatertDeltakelsmengde.gjeldende?.deltakelsesprosent,
         dagerPerUke = oppdatertDeltakelsmengde.gjeldende?.dagerPerUke,


### PR DESCRIPTION
Dette sånn at Legg til oppstart endring på VTA kan ha null som sluttdato uten at det påvirker sluttdato på deltakelsen
(nå sendes sluttdato med i veileders flate, selv om sluttdato ikke er oppgitt av bruker)

https://trello.com/c/7c2mUSYU/2017-bug-vta-sender-med-sluttdato-n%C3%A5r-man-endrer-oppstartsdato-dersom-deltaker-har-sluttdato