### PR TITLE
støtte for å fjerne oppstartsdato

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ val caffeineVersion = "3.1.8"
 val mockkVersion = "1.13.13"
 val nimbusVersion = "9.47"
 val unleashVersion = "9.2.6"
-val amtLibVersion = "1.2024.12.16_11.44-f6e1d4a5b217"
+val amtLibVersion = "1.2024.12.17_06.59-e07da90fb22a"
 val awaitilityVersion = "4.2.2"
 
 dependencies {

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApi.kt
@@ -14,6 +14,7 @@ import no.nav.amt.deltaker.deltaker.api.model.AvsluttDeltakelseRequest
 import no.nav.amt.deltaker.deltaker.api.model.BakgrunnsinformasjonRequest
 import no.nav.amt.deltaker.deltaker.api.model.DeltakelsesmengdeRequest
 import no.nav.amt.deltaker.deltaker.api.model.EndringRequest
+import no.nav.amt.deltaker.deltaker.api.model.FjernOppstartsdatoRequest
 import no.nav.amt.deltaker.deltaker.api.model.ForlengDeltakelseRequest
 import no.nav.amt.deltaker.deltaker.api.model.IkkeAktuellRequest
 import no.nav.amt.deltaker.deltaker.api.model.InnholdRequest
@@ -82,6 +83,11 @@ fun Routing.registerDeltakerApi(deltakerService: DeltakerService, historikkServi
 
         post("/deltaker/{deltakerId}/reaktiver") {
             val request = call.receive<ReaktiverDeltakelseRequest>()
+            call.handleDeltakerEndring(deltakerService, request, historikkService)
+        }
+
+        post("/deltaker/{deltakerId}/fjern-oppstartsdato") {
+            val request = call.receive<FjernOppstartsdatoRequest>()
             call.handleDeltakerEndring(deltakerService, request, historikkService)
         }
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
@@ -86,6 +86,13 @@ data class AvsluttDeltakelseRequest(
     val begrunnelse: String?,
 ) : EndringForslagRequest
 
+data class FjernOppstartsdatoRequest(
+    override val endretAv: String,
+    override val endretAvEnhet: String,
+    override val forslagId: UUID?,
+    val begrunnelse: String?,
+) : EndringForslagRequest
+
 data class ReaktiverDeltakelseRequest(
     override val endretAv: String,
     override val endretAvEnhet: String,
@@ -133,4 +140,8 @@ fun EndringRequest.toDeltakerEndringEndring() = when (this) {
             sluttdato = this.sluttdato,
             this.begrunnelse,
         )
+
+    is FjernOppstartsdatoRequest -> DeltakerEndring.Endring.FjernOppstartsdato(
+        begrunnelse = this.begrunnelse,
+    )
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
@@ -28,6 +28,7 @@ class DeltakerEndringHandler(
         is DeltakerEndring.Endring.ForlengDeltakelse -> forlengDeltakelse(endring)
         is DeltakerEndring.Endring.IkkeAktuell -> ikkeAktuell(endring)
         is DeltakerEndring.Endring.ReaktiverDeltakelse -> reaktiverDeltakelse()
+        is DeltakerEndring.Endring.FjernOppstartsdato -> fjernOppstartsdato()
     }
 
     private fun endreDeltaker(erEndret: Boolean, block: () -> DeltakerEndringUtfall.VellykketEndring) = if (erEndret) {
@@ -130,6 +131,15 @@ class DeltakerEndringHandler(
                 deltaker.copy(bakgrunnsinformasjon = endring.bakgrunnsinformasjon),
             )
         }
+
+    private fun fjernOppstartsdato() = endreDeltaker(deltaker.startdato != null) {
+        DeltakerEndringUtfall.VellykketEndring(
+            deltaker.copy(
+                startdato = null,
+                sluttdato = null,
+            ),
+        )
+    }
 
     private fun avsluttDeltakelses(endring: DeltakerEndring.Endring.AvsluttDeltakelse) = endreDeltaker(
         deltaker.status.type != DeltakerStatus.Type.HAR_SLUTTET ||

--- a/src/main/kotlin/no/nav/amt/deltaker/hendelse/model/HendelseType.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/hendelse/model/HendelseType.kt
@@ -96,6 +96,12 @@ sealed interface HendelseType {
         override val endringFraForslag: Forslag.Endring?,
     ) : HendelseMedForslag
 
+    data class FjernOppstartsdato(
+        override val begrunnelseFraNav: String?,
+        override val begrunnelseFraArrangor: String?,
+        override val endringFraForslag: Forslag.Endring?,
+    ) : HendelseMedForslag
+
     data class DeltakerSistBesokt(
         val sistBesokt: ZonedDateTime,
     ) : HendelseType
@@ -183,6 +189,12 @@ fun DeltakerEndring.toHendelseEndring(utkast: UtkastDto? = null) = when (val end
 
     is DeltakerEndring.Endring.IkkeAktuell -> HendelseType.IkkeAktuell(
         aarsak = endring.aarsak,
+        begrunnelseFraNav = endring.begrunnelse,
+        begrunnelseFraArrangor = forslag?.begrunnelse,
+        endringFraForslag = forslag?.endring,
+    )
+
+    is DeltakerEndring.Endring.FjernOppstartsdato -> HendelseType.FjernOppstartsdato(
         begrunnelseFraNav = endring.begrunnelse,
         begrunnelseFraArrangor = forslag?.begrunnelse,
         endringFraForslag = forslag?.endring,


### PR DESCRIPTION
https://trello.com/c/pr6SFIj6/1968-muligheten-for-%C3%A5-nulle-ut-datoer-og-tilbakef%C3%B8re-brukeren-til-venter-p%C3%A5-oppstart-uten-datoer