### PR TITLE
Endrer ansvarsfordeling ved endring av deltakere for å gjøre koden mer lesbar

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/Application.kt
@@ -218,6 +218,7 @@ fun Application.module() {
         endringFraArrangorService = endringFraArrangorService,
         forslagService = forslagService,
         importertFraArenaRepository = importertFraArenaRepository,
+        deltakerHistorikkService = deltakerHistorikkService,
     )
     val pameldingService = PameldingService(
         deltakerService = deltakerService,

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandler.kt
@@ -17,7 +17,7 @@ class DeltakerEndringHandler(
     val endring: DeltakerEndring.Endring,
     private val deltakerHistorikkService: DeltakerHistorikkService,
 ) {
-    fun handle(): DeltakerEndringUtfall = when (endring) {
+    fun sjekkUtfall(): DeltakerEndringUtfall = when (endring) {
         is DeltakerEndring.Endring.AvsluttDeltakelse -> avsluttDeltakelses(endring)
         is DeltakerEndring.Endring.EndreBakgrunnsinformasjon -> endreBakgrunnsinformasjon(endring)
         is DeltakerEndring.Endring.EndreDeltakelsesmengde -> endreDeltakelsesmengde(endring)

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
@@ -106,6 +106,7 @@ class PameldingServiceTest {
             endringFraArrangorService = endringFraArrangorService,
             forslagService = forslagService,
             importertFraArenaRepository = importertFraArenaRepository,
+            deltakerHistorikkService = deltakerHistorikkService,
         )
 
         private var pameldingService = PameldingService(

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
@@ -1,14 +1,35 @@
 package no.nav.amt.deltaker.deltaker.endring
 
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.amt.deltaker.deltaker.DeltakerHistorikkService
+import no.nav.amt.deltaker.deltaker.api.model.AvsluttDeltakelseRequest
+import no.nav.amt.deltaker.deltaker.api.model.ReaktiverDeltakelseRequest
+import no.nav.amt.deltaker.deltaker.api.model.SluttarsakRequest
+import no.nav.amt.deltaker.deltaker.api.model.SluttdatoRequest
+import no.nav.amt.deltaker.deltaker.api.model.StartdatoRequest
+import no.nav.amt.deltaker.deltaker.api.model.toDeltakerEndringEndring
 import no.nav.amt.deltaker.utils.data.TestData
+import no.nav.amt.lib.models.arrangor.melding.EndringAarsak
+import no.nav.amt.lib.models.arrangor.melding.Forslag
+import no.nav.amt.lib.models.deltaker.DeltakerEndring
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import no.nav.amt.lib.models.deltaker.deltakelsesmengde.Deltakelsesmengde
 import no.nav.amt.lib.models.deltaker.deltakelsesmengde.Deltakelsesmengder
+import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
 
 class DeltakerEndringHandlerTest {
+    val deltakerHistorikkServiceMock = mockk<DeltakerHistorikkService>()
+
+    @Before
+    fun setup() {
+        every { deltakerHistorikkServiceMock.getForDeltaker(any()) } returns emptyList()
+    }
+
     @Test
     fun `endreDeltakersOppstart - fremtidig startdato - endrer også deltakelsesmengde`() {
         val nyStartdato = LocalDate.now().plusMonths(1)
@@ -115,5 +136,333 @@ class DeltakerEndringHandlerTest {
         endretDeltaker.startdato shouldBe nyStartdato
         endretDeltaker.dagerPerUke shouldBe gjeldendeMengde.dagerPerUke
         endretDeltaker.deltakelsesprosent shouldBe gjeldendeMengde.deltakelsesprosent
+    }
+
+    @Test
+    fun `sjekkUtfall - endret start- og sluttdato i fortid, venter pa oppstart - deltaker blir ikke aktuell`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.VENTER_PA_OPPSTART))
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = StartdatoRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            startdato = LocalDate.now().minusWeeks(10),
+            sluttdato = LocalDate.now().minusDays(4),
+            begrunnelse = null,
+            forslagId = null,
+        )
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.IKKE_AKTUELL
+        deltakerResult.startdato shouldBe null
+        deltakerResult.sluttdato shouldBe null
+    }
+
+    @Test
+    fun `sjekkUtfall - endret start- og sluttdato i fortid, deltar - deltaker blir har sluttet`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR))
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = StartdatoRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            startdato = LocalDate.now().minusWeeks(10),
+            sluttdato = LocalDate.now().minusDays(4),
+            begrunnelse = null,
+            forslagId = null,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        deltakerResult.startdato shouldBe endringsrequest.startdato
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
+    }
+
+    @Test
+    fun `sjekkUtfall - endret start- og sluttdato i fremtid, deltar - deltaker blir venter pa oppstart`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR))
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = StartdatoRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            startdato = LocalDate.now().plusDays(10),
+            sluttdato = LocalDate.now().plusWeeks(4),
+            begrunnelse = null,
+            forslagId = null,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.VENTER_PA_OPPSTART
+        deltakerResult.startdato shouldBe endringsrequest.startdato
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
+    }
+
+    @Test
+    fun `sjekkUtfall - endret start- og sluttdato i fremtid, har sluttet - deltaker blir deltar`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(
+            startdato = LocalDate.now().minusMonths(1),
+            sluttdato = LocalDate.now().minusDays(1),
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET),
+        )
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+
+        val endringsrequest = StartdatoRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            startdato = LocalDate.now().minusDays(10),
+            sluttdato = LocalDate.now().plusWeeks(4),
+            begrunnelse = null,
+            forslagId = null,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.DELTAR
+        deltakerResult.startdato shouldBe endringsrequest.startdato
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
+    }
+
+    @Test
+    fun `sjekkUtfall - endret sluttdato`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker()
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = SluttdatoRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            forslagId = null,
+            sluttdato = LocalDate.now().minusWeeks(1),
+            begrunnelse = "begrunnelse",
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val oppdatertDeltaker = resultat.getOrThrow()
+        oppdatertDeltaker.sluttdato shouldBe endringsrequest.sluttdato
+        oppdatertDeltaker.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+    }
+
+    @Test
+    fun `sjekkUtfall - endret sluttdato frem i tid - endrer status og sluttdato`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker()
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = SluttdatoRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            forslagId = null,
+            sluttdato = LocalDate.now().plusWeeks(1),
+            begrunnelse = "begrunnelse",
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val oppdatertDeltaker = resultat.getOrThrow()
+        oppdatertDeltaker.sluttdato shouldBe endringsrequest.sluttdato
+        oppdatertDeltaker.status.type shouldBe DeltakerStatus.Type.DELTAR
+    }
+
+    @Test
+    fun `sjekkUtfall - endret sluttarsak`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET, aarsak = DeltakerStatus.Aarsak.Type.SYK),
+        )
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+
+        val endringsrequest = SluttarsakRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            aarsak = DeltakerEndring.Aarsak(DeltakerEndring.Aarsak.Type.FATT_JOBB, null),
+            begrunnelse = null,
+            forslagId = null,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val oppdatertDeltaker = resultat.getOrThrow()
+        oppdatertDeltaker.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        oppdatertDeltaker.status.aarsak?.type shouldBe DeltakerStatus.Aarsak.Type.FATT_JOBB
+    }
+
+    @Test
+    fun `sjekkUtfall - avslutt deltakelse`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            sluttdato = LocalDate.now().plusMonths(1),
+        )
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val forslag = TestData.lagForslag(
+            deltakerId = deltaker.id,
+            endring = Forslag.AvsluttDeltakelse(LocalDate.now(), EndringAarsak.FattJobb, null),
+        )
+        val endringsrequest = AvsluttDeltakelseRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            sluttdato = LocalDate.now(),
+            aarsak = DeltakerEndring.Aarsak(DeltakerEndring.Aarsak.Type.FATT_JOBB, null),
+            begrunnelse = "begrunnelse",
+            forslagId = forslag.id,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        deltakerResult.status.aarsak?.type shouldBe DeltakerStatus.Aarsak.Type.FATT_JOBB
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
+    }
+
+    @Test
+    fun `sjekkUtfall - avslutt deltakelse i fremtiden - deltaker får ny sluttdato, fremtidig status`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            sluttdato = LocalDate.now().plusMonths(1),
+        )
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = AvsluttDeltakelseRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            sluttdato = LocalDate.now().plusWeeks(1),
+            aarsak = DeltakerEndring.Aarsak(DeltakerEndring.Aarsak.Type.FATT_JOBB, null),
+            begrunnelse = null,
+            forslagId = null,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+        resultat.erVellykket shouldBe true
+
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        deltakerResult.status.gyldigFra.toLocalDate() shouldBe endringsrequest.sluttdato.plusDays(1)
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
+    }
+
+    @Test
+    fun `sjekkUtfall - har sluttet, avslutt deltakelse i fremtiden - ny sluttdato, fremtidig status`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET),
+            sluttdato = LocalDate.now().minusWeeks(1),
+        )
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = AvsluttDeltakelseRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            sluttdato = LocalDate.now().plusWeeks(1),
+            aarsak = DeltakerEndring.Aarsak(DeltakerEndring.Aarsak.Type.FATT_JOBB, null),
+            begrunnelse = null,
+            forslagId = null,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        resultat as DeltakerEndringUtfall.VellykketEndring
+        val deltakerResult = resultat.deltaker
+        val nesteStatus = resultat.nesteStatus
+
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.DELTAR
+        deltakerResult.status.gyldigFra.toLocalDate() shouldBe LocalDate.now()
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
+
+        nesteStatus?.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        nesteStatus?.aarsak?.type shouldBe DeltakerStatus.Aarsak.Type.FATT_JOBB
+        nesteStatus?.gyldigFra?.toLocalDate() shouldBe endringsrequest.sluttdato.plusDays(1)
+        nesteStatus?.gyldigTil shouldBe null
+    }
+
+    @Test
+    fun `sjekkUtfall - har sluttet, avslutt deltakelse i fortid - returnerer deltaker med ny sluttdato`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET),
+            sluttdato = LocalDate.now().minusWeeks(1),
+        )
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = AvsluttDeltakelseRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            sluttdato = LocalDate.now().minusDays(1),
+            aarsak = DeltakerEndring.Aarsak(DeltakerEndring.Aarsak.Type.FATT_JOBB, null),
+            begrunnelse = null,
+            forslagId = null,
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        resultat as DeltakerEndringUtfall.VellykketEndring
+        val deltakerResult = resultat.deltaker
+        val nesteStatus = resultat.nesteStatus
+
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        deltakerResult.status.aarsak?.type shouldBe DeltakerStatus.Aarsak.Type.FATT_JOBB
+        deltakerResult.status.gyldigFra.toLocalDate() shouldBe LocalDate.now()
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
+
+        nesteStatus shouldBe null
+    }
+
+    @Test
+    fun `sjekkUtfall - reaktiver deltakelse`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.IKKE_AKTUELL))
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = ReaktiverDeltakelseRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            begrunnelse = "begrunnelse",
+        )
+
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.VENTER_PA_OPPSTART
+        deltakerResult.startdato shouldBe null
+        deltakerResult.sluttdato shouldBe null
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringServiceTest.kt
@@ -85,7 +85,7 @@ class DeltakerStatusOppdateringServiceTest {
         private val forslagService = ForslagService(forslagRepository, mockk(), deltakerRepository, deltakerProducerService)
 
         private val deltakerEndringService = DeltakerEndringService(
-            repository = deltakerEndringRepository,
+            deltakerEndringRepository = deltakerEndringRepository,
             navAnsattService = navAnsattService,
             navEnhetService = navEnhetService,
             hendelseService = hendelseService,
@@ -112,6 +112,7 @@ class DeltakerStatusOppdateringServiceTest {
                 endringFraArrangorService,
                 forslagService,
                 importertFraArenaRepository,
+                deltakerHistorikkService,
             )
             deltakerStatusOppdateringService = DeltakerStatusOppdateringService(deltakerRepository, deltakerService, unleashToggle)
         }


### PR DESCRIPTION
En endring i ansvarsfordeling i koden i forsøk på å gjøre koden lettere å forstå.

Jeg brukte lang tid på å forstå koden sånn som den var så håper dette blir mer forståelig også for andre

* Metoden som "kalkulerte" de faktiske endringene på deltakerobjektet het DeltakerEndringHandler.handle() som førte til at jeg trodde at denne metoden faktisk insertet endringen i database, har derfor renamet funsjonen til sjekkUtfall() som vil returnere både endringstypen( FremtidigEndring, VellykketEndring osv ) og det resulterende deltakerobjektet som senere kan insertes.
* Tidligere var det DeltakerEndringService som hadde ansvar for å utlede endringer på deltakerobjektet. Det var her man "regnet ut"(via DeltakerEndringHandler) endringer på deltakeren som igjen ble returnert som "utfall" og resultatet ble brukt av DeltakerService. Jeg syns flyten var vanskelig å forstå og har derfor flyttet koden opp til DeltakerService for å flate ut strukturen og håper det kan gjøre tydeligere hvor faktiske inserts skjer og forhåpentligvis legge tilrette for transaksjonshåntering
* Flyttet en del tester som endte opp med å feile etter endringene. Har flyttet de testene soom sjekket mange kombinasjoner av resultatet til enhetstester på sjekkUtfall
* De andre er flyttet til DeltakerServiceTest og kunne da i tillegg asserte på deltaker i deltakerrepository