### PR TITLE
sluttdato i fortid skal gi har_sluttet

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringService.kt
@@ -100,13 +100,12 @@ class DeltakerEndringService(
 }
 
 fun Deltaker.getStatusEndretStartOgSluttdato(startdato: LocalDate?, sluttdato: LocalDate?): DeltakerStatus =
-    if (status.type == DeltakerStatus.Type.VENTER_PA_OPPSTART && (
-            startdato != null && sluttdato != null && sluttdato.isBefore(
-                LocalDate.now(),
-            )
-        )
-    ) {
-        nyDeltakerStatus(DeltakerStatus.Type.HAR_SLUTTET)
+    if (status.type == DeltakerStatus.Type.VENTER_PA_OPPSTART && (sluttdato != null && sluttdato.isBefore(LocalDate.now()))) {
+        if (startdato == null) {
+            nyDeltakerStatus(DeltakerStatus.Type.IKKE_AKTUELL)
+        } else {
+            nyDeltakerStatus(DeltakerStatus.Type.HAR_SLUTTET)
+        }
     } else if (status.type == DeltakerStatus.Type.VENTER_PA_OPPSTART && (startdato != null && !startdato.isAfter(LocalDate.now()))) {
         nyDeltakerStatus(DeltakerStatus.Type.DELTAR)
     } else if (status.type == DeltakerStatus.Type.DELTAR && (sluttdato != null && sluttdato.isBefore(LocalDate.now()))) {

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringService.kt
@@ -100,8 +100,13 @@ class DeltakerEndringService(
 }
 
 fun Deltaker.getStatusEndretStartOgSluttdato(startdato: LocalDate?, sluttdato: LocalDate?): DeltakerStatus =
-    if (status.type == DeltakerStatus.Type.VENTER_PA_OPPSTART && (sluttdato != null && sluttdato.isBefore(LocalDate.now()))) {
-        nyDeltakerStatus(DeltakerStatus.Type.IKKE_AKTUELL)
+    if (status.type == DeltakerStatus.Type.VENTER_PA_OPPSTART && (
+            startdato != null && sluttdato != null && sluttdato.isBefore(
+                LocalDate.now(),
+            )
+        )
+    ) {
+        nyDeltakerStatus(DeltakerStatus.Type.HAR_SLUTTET)
     } else if (status.type == DeltakerStatus.Type.VENTER_PA_OPPSTART && (startdato != null && !startdato.isAfter(LocalDate.now()))) {
         nyDeltakerStatus(DeltakerStatus.Type.DELTAR)
     } else if (status.type == DeltakerStatus.Type.DELTAR && (sluttdato != null && sluttdato.isBefore(LocalDate.now()))) {

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
@@ -139,7 +139,7 @@ class DeltakerEndringHandlerTest {
     }
 
     @Test
-    fun `sjekkUtfall - endret start- og sluttdato i fortid, venter pa oppstart - deltaker blir ikke aktuell`(): Unit = runBlocking {
+    fun `sjekkUtfall - endret start- og sluttdato i fortid, venter pa oppstart - deltaker blir har sluttet`(): Unit = runBlocking {
         val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.VENTER_PA_OPPSTART))
         val endretAv = TestData.lagNavAnsatt()
         val endretAvEnhet = TestData.lagNavEnhet()
@@ -157,9 +157,9 @@ class DeltakerEndringHandlerTest {
 
         resultat.erVellykket shouldBe true
         val deltakerResult = resultat.getOrThrow()
-        deltakerResult.status.type shouldBe DeltakerStatus.Type.IKKE_AKTUELL
-        deltakerResult.startdato shouldBe null
-        deltakerResult.sluttdato shouldBe null
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+        deltakerResult.startdato shouldBe endringsrequest.startdato
+        deltakerResult.sluttdato shouldBe endringsrequest.sluttdato
     }
 
     @Test

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/DeltakerEndringHandlerTest.kt
@@ -163,6 +163,30 @@ class DeltakerEndringHandlerTest {
     }
 
     @Test
+    fun `sjekkUtfall - endret sluttdato i fortid, startdato mangler, venter pa oppstart - blir ikke aktuell`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.VENTER_PA_OPPSTART))
+        val endretAv = TestData.lagNavAnsatt()
+        val endretAvEnhet = TestData.lagNavEnhet()
+        val endringsrequest = StartdatoRequest(
+            endretAv = endretAv.navIdent,
+            endretAvEnhet = endretAvEnhet.enhetsnummer,
+            startdato = null,
+            sluttdato = LocalDate.now().minusDays(4),
+            begrunnelse = null,
+            forslagId = null,
+        )
+        val deltakerEndringHandler =
+            DeltakerEndringHandler(deltaker, endringsrequest.toDeltakerEndringEndring(), deltakerHistorikkServiceMock)
+        val resultat = deltakerEndringHandler.sjekkUtfall()
+
+        resultat.erVellykket shouldBe true
+        val deltakerResult = resultat.getOrThrow()
+        deltakerResult.status.type shouldBe DeltakerStatus.Type.IKKE_AKTUELL
+        deltakerResult.startdato shouldBe null
+        deltakerResult.sluttdato shouldBe null
+    }
+
+    @Test
     fun `sjekkUtfall - endret start- og sluttdato i fortid, deltar - deltaker blir har sluttet`(): Unit = runBlocking {
         val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR))
         val endretAv = TestData.lagNavAnsatt()

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/endring/fra/arrangor/EndringFraArrangorServiceTest.kt
@@ -292,7 +292,7 @@ class EndringFraArrangorServiceTest {
 
             resultat.isSuccess shouldBe true
             resultat.getOrThrow().startdato shouldBe startdato
-            // resultat.getOrThrow().sluttdato shouldBe sluttdato
+            resultat.getOrThrow().sluttdato shouldBe sluttdato
             resultat.getOrThrow().status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
 
             val endring = endringFraArrangorRepository.getForDeltaker(deltaker.id).first()


### PR DESCRIPTION
https://trello.com/c/L87U5g5O/2058-bug-g%C3%A5r-til-ikke-aktuell-n%C3%A5r-man-registrerer-periode-med-sluttdato-tilbake-i-tid