### PR TITLE
skal ikke feile ved vurdering på deltaker som ikke finnes

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/forslag/kafka/ArrangorMeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/forslag/kafka/ArrangorMeldingConsumer.kt
@@ -45,7 +45,7 @@ class ArrangorMeldingConsumer(
         }
 
         val melding = objectMapper.readValue<Melding>(value)
-        if (!forslagService.kanLagres(melding.deltakerId)) {
+        if (!forslagService.kanLagres(melding.deltakerId) && melding !is Vurdering) {
             if (isDev) {
                 log.error("Mottatt melding ${melding.id} på deltaker som ikke finnes, deltakerid ${melding.deltakerId}, ignorerer")
                 return


### PR DESCRIPTION
Siden vi skriver vurderinger til topic for deltakere som vi ikke har i amt-deltaker ennå skal det ikke feile hvis man mottar en slik vurdering nå. Når vi tar over kurstiltakene bør nok dette endres. 