### PR TITLE
Lager ny versjon av del med arrangør for å rette problem med at historikk ikke blir populert riktig i bff

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/tiltakskoordinator/TiltakskoordinatorApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/tiltakskoordinator/TiltakskoordinatorApi.kt
@@ -29,6 +29,17 @@ fun Routing.registerTiltakskoordinatorApi(deltakerService: DeltakerService) {
             call.respond(deltakere.map { it.toResponse() })
         }
 
+        post("$apiPath/del-med-arrangor-v2") {
+            val request = call.receive<DelMedArrangorRequest>()
+
+            val oppdaterteDeltakere = deltakerService.upsertEndretDeltakere(
+                request.deltakerIder,
+                EndringFraTiltakskoordinator.DelMedArrangor,
+                request.endretAv,
+            ).toDeltakereResponse()
+            call.respond(oppdaterteDeltakere)
+        }
+
         post("$apiPath/sett-paa-venteliste") {
             val request = call.receive<DeltakereRequest>()
             val deltakerIder = request.deltakere


### PR DESCRIPTION
Problemet er at amt-deltaker returnerer ikke historikk i det gamle endepunktet som fører til race condition når bff både upserter når man kaller del-med-arrangør og når man får record på topic

