### PR TITLE
Lager nytt endepunkt for avbrytelse av deltaker og tilpasser avslutt deltakelse for felles inntak

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ val caffeineVersion = "3.2.0"
 val mockkVersion = "1.14.2"
 val nimbusVersion = "10.3"
 val unleashVersion = "10.2.2"
-val amtLibVersion = "1.2025.05.14_12.02-7560e33657f6"
+val amtLibVersion = "1.2025.05.15_09.16-f1f642edbddb"
 val awaitilityVersion = "4.3.0"
 
 dependencies {

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApi.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import no.nav.amt.deltaker.deltaker.DeltakerHistorikkService
 import no.nav.amt.deltaker.deltaker.DeltakerService
+import no.nav.amt.deltaker.deltaker.api.model.AvbrytDeltakelseRequest
 import no.nav.amt.deltaker.deltaker.api.model.AvsluttDeltakelseRequest
 import no.nav.amt.deltaker.deltaker.api.model.BakgrunnsinformasjonRequest
 import no.nav.amt.deltaker.deltaker.api.model.DeltakelsesmengdeRequest
@@ -79,6 +80,11 @@ fun Routing.registerDeltakerApi(deltakerService: DeltakerService, historikkServi
 
         post("/deltaker/{deltakerId}/avslutt") {
             val request = call.receive<AvsluttDeltakelseRequest>()
+            call.handleDeltakerEndring(deltakerService, request, historikkService)
+        }
+
+        post("/deltaker/{deltakerId}/avbryt") {
+            val request = call.receive<AvbrytDeltakelseRequest>()
             call.handleDeltakerEndring(deltakerService, request, historikkService)
         }
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/api/model/EndringRequest.kt
@@ -82,6 +82,15 @@ data class AvsluttDeltakelseRequest(
     override val endretAvEnhet: String,
     override val forslagId: UUID?,
     val sluttdato: LocalDate,
+    val aarsak: DeltakerEndring.Aarsak?,
+    val begrunnelse: String?,
+) : EndringForslagRequest
+
+data class AvbrytDeltakelseRequest(
+    override val endretAv: String,
+    override val endretAvEnhet: String,
+    override val forslagId: UUID?,
+    val sluttdato: LocalDate,
     val aarsak: DeltakerEndring.Aarsak,
     val begrunnelse: String?,
 ) : EndringForslagRequest
@@ -111,6 +120,11 @@ fun EndringRequest.toDeltakerEndringEndring() = when (this) {
     is ForlengDeltakelseRequest -> DeltakerEndring.Endring.ForlengDeltakelse(this.sluttdato, this.begrunnelse)
     is IkkeAktuellRequest -> DeltakerEndring.Endring.IkkeAktuell(this.aarsak, this.begrunnelse)
     is AvsluttDeltakelseRequest -> DeltakerEndring.Endring.AvsluttDeltakelse(
+        this.aarsak,
+        this.sluttdato,
+        this.begrunnelse,
+    )
+    is AvbrytDeltakelseRequest -> DeltakerEndring.Endring.AvbrytDeltakelse(
         this.aarsak,
         this.sluttdato,
         this.begrunnelse,

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DeltakerRepository.kt
@@ -133,7 +133,7 @@ class DeltakerRepository {
             tx.update(queryOf(sql, parameters))
             tx.update(insertStatusQuery(deltaker.status, deltaker.id))
             if (!deltaker.status.gyldigFra
-                    .toLocalDate()
+                    .toLocalDate() // Hæ?
                     .isAfter(LocalDate.now())
             ) {
                 tx.update(deaktiverTidligereStatuserQuery(deltaker.status, deltaker.id))

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DeltakerRepository.kt
@@ -133,7 +133,7 @@ class DeltakerRepository {
             tx.update(queryOf(sql, parameters))
             tx.update(insertStatusQuery(deltaker.status, deltaker.id))
             if (!deltaker.status.gyldigFra
-                    .toLocalDate() // Hæ?
+                    .toLocalDate()
                     .isAfter(LocalDate.now())
             ) {
                 tx.update(deaktiverTidligereStatuserQuery(deltaker.status, deltaker.id))

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApiTest.kt
@@ -328,7 +328,7 @@ class DeltakerApiTest {
         val deltaker = TestData.lagDeltaker(
             status = TestData.lagDeltakerStatus(
                 type = DeltakerStatus.Type.HAR_SLUTTET,
-                aarsak = DeltakerStatus.Aarsak.Type.valueOf(endring.aarsak.type.name),
+                aarsak = DeltakerStatus.Aarsak.Type.valueOf(endring.aarsak!!.type.name),
             ),
             sluttdato = endring.sluttdato,
         )

--- a/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
@@ -116,7 +116,7 @@ object TestData {
 
     fun lagTiltakstype(
         id: UUID = UUID.randomUUID(),
-        tiltakskode: Tiltakstype.Tiltakskode = Tiltakstype.Tiltakskode.entries.random(),
+        tiltakskode: Tiltakstype.Tiltakskode = Tiltakstype.Tiltakskode.OPPFOLGING,
         arenaKode: Tiltakstype.ArenaKode = tiltakskode.toArenaKode(),
         navn: String = "Test tiltak $arenaKode",
         innsatsgrupper: Set<Innsatsgruppe> = setOf(Innsatsgruppe.STANDARD_INNSATS),


### PR DESCRIPTION
* Nytt endepunkt for avbryt deltakelse som skal brukes når deltakelsen på felles oppstart ikke har blitt fullført
* Tilpasser avslutt deltakelse endepunkt for å fungere deltakere på felles oppstart
* Retter testdata sånn at man ikke får tilfeldige utfall på tiltakstype

https://trello.com/c/dmPgsl3w/2163-tiltaksarrang%C3%B8r-avslutte-deltakelse-modal-skal-man-angi-om-kurset-er-fullf%C3%B8rt-eller-ikke