### PR TITLE
Oppstartstype skal ikke være nullable

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/PameldingService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/PameldingService.kt
@@ -108,7 +108,7 @@ class PameldingService(
         val endretAv = navAnsattService.hentEllerOpprettNavAnsatt(utkast.endretAv)
         val endretAvNavEnhet = navEnhetService.hentEllerOpprettNavEnhet(utkast.endretAvEnhet)
 
-        val fattet = utkast.godkjentAvNav && !oppdatertDeltaker.deltakerliste.erKurs()
+        val fattet = utkast.godkjentAvNav && !oppdatertDeltaker.deltakerliste.erFellesOppstart
 
         val vedtak = if (fattet) {
             vedtakService.navFattEksisterendeEllerOpprettVedtak(oppdatertDeltaker, endretAv, endretAvNavEnhet)
@@ -122,7 +122,7 @@ class PameldingService(
 
         val deltakerMedNyttVedtak = oppdatertDeltaker.copy(vedtaksinformasjon = vedtak.tilVedtaksinformasjon())
 
-        if (utkast.godkjentAvNav && oppdatertDeltaker.deltakerliste.erKurs()) {
+        if (utkast.godkjentAvNav && oppdatertDeltaker.deltakerliste.erFellesOppstart) {
             innsokPaaFellesOppstartService.nyttInnsokUtkastGodkjentAvNav(deltakerMedNyttVedtak, opprinneligDeltaker.status)
         }
 
@@ -146,7 +146,7 @@ class PameldingService(
     suspend fun innbyggerGodkjennUtkast(deltakerId: UUID): Deltaker {
         val opprinneligDeltaker = deltakerService.get(deltakerId).getOrThrow()
 
-        val oppdatertDeltaker = if (opprinneligDeltaker.deltakerliste.erKurs()) {
+        val oppdatertDeltaker = if (opprinneligDeltaker.deltakerliste.erFellesOppstart) {
             innbyggerGodkjennInnsok(opprinneligDeltaker)
         } else {
             deltakerService.innbyggerFattVedtak(opprinneligDeltaker)
@@ -219,7 +219,7 @@ class PameldingService(
     )
 
     private fun getOppdatertStatus(opprinneligDeltaker: Deltaker, godkjentAvNav: Boolean): DeltakerStatus = if (godkjentAvNav) {
-        if (opprinneligDeltaker.deltakerliste.erKurs()) {
+        if (opprinneligDeltaker.deltakerliste.erFellesOppstart) {
             nyDeltakerStatus(DeltakerStatus.Type.SOKT_INN)
         } else if (opprinneligDeltaker.startdato != null && opprinneligDeltaker.startdato.isBefore(LocalDate.now())) {
             nyDeltakerStatus(DeltakerStatus.Type.DELTAR)

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/Deltaker.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/Deltaker.kt
@@ -31,7 +31,7 @@ data class Deltaker(
 ) {
     fun harSluttet(): Boolean = status.type in AVSLUTTENDE_STATUSER
 
-    fun deltarPaKurs(): Boolean = deltakerliste.erKurs()
+    fun deltarPaKurs(): Boolean = deltakerliste.erFellesOppstart
 
     fun toDeltakerVedVedtak(): DeltakerVedVedtak = DeltakerVedVedtak(
         id = id,

--- a/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/Deltakerliste.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/Deltakerliste.kt
@@ -12,7 +12,7 @@ data class Deltakerliste(
     val status: Status,
     val startDato: LocalDate,
     val sluttDato: LocalDate? = null,
-    val oppstart: Oppstartstype?,
+    val oppstart: Oppstartstype,
     val apentForPamelding: Boolean,
     val arrangor: Arrangor,
 ) {
@@ -44,10 +44,4 @@ data class Deltakerliste(
     fun erAvsluttet(): Boolean = erAvlystEllerAvbrutt() || status == Status.AVSLUTTET
 
     val erFellesOppstart get() = oppstart == Oppstartstype.FELLES
-
-    fun erKurs(): Boolean = if (oppstart != null) {
-        oppstart == Oppstartstype.FELLES
-    } else {
-        tiltakstype.erKurs()
-    }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/kafka/DeltakerlisteDto.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/kafka/DeltakerlisteDto.kt
@@ -13,7 +13,7 @@ data class DeltakerlisteDto(
     val sluttDato: LocalDate? = null,
     val status: String,
     val virksomhetsnummer: String,
-    val oppstart: Deltakerliste.Oppstartstype?,
+    val oppstart: Deltakerliste.Oppstartstype,
     val apentForPamelding: Boolean?,
 ) {
     data class Tiltakstype(

--- a/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
@@ -142,7 +142,7 @@ object TestData {
         status: Deltakerliste.Status = Deltakerliste.Status.GJENNOMFORES,
         startDato: LocalDate = LocalDate.now().minusMonths(1),
         sluttDato: LocalDate? = LocalDate.now().plusYears(1),
-        oppstart: Deltakerliste.Oppstartstype? = finnOppstartstype(tiltakstype.arenaKode),
+        oppstart: Deltakerliste.Oppstartstype = finnOppstartstype(tiltakstype.arenaKode),
         apentForPamelding: Boolean = true,
     ) = Deltakerliste(id, tiltakstype, navn, status, startDato, sluttDato, oppstart, apentForPamelding, arrangor)
 


### PR DESCRIPTION
Relast er kjørt så oppstartstype vil ikke kunne være null, som ville kunne medføre rare feil med tolkning av oppstartstypen
https://trello.com/c/DoT0srVq/2231-oppstartstype-skal-ikke-v%C3%A6re-nullable-i-amt-deltaker