### PR TITLE
api for å opprette testdeltakelser

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/Application.kt
@@ -67,6 +67,7 @@ import no.nav.amt.deltaker.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.navbruker.NavBrukerConsumer
 import no.nav.amt.deltaker.navbruker.NavBrukerRepository
 import no.nav.amt.deltaker.navbruker.NavBrukerService
+import no.nav.amt.deltaker.testdata.TestdataService
 import no.nav.amt.deltaker.tiltakskoordinator.endring.EndringFraTiltakskoordinatorRepository
 import no.nav.amt.deltaker.tiltakskoordinator.endring.EndringFraTiltakskoordinatorService
 import no.nav.amt.deltaker.unleash.UnleashToggle
@@ -215,8 +216,9 @@ fun Application.module() {
     val deltakerV1Producer = DeltakerV1Producer(kafkaProducer)
     val deltakerProducerService = DeltakerProducerService(deltakerDtoMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
 
+    val arrangorMeldingProducer = ArrangorMeldingProducer(kafkaProducer)
     val forslagService =
-        ForslagService(forslagRepository, ArrangorMeldingProducer(kafkaProducer), deltakerRepository, deltakerProducerService)
+        ForslagService(forslagRepository, arrangorMeldingProducer, deltakerRepository, deltakerProducerService)
 
     val deltakerEndringService =
         DeltakerEndringService(
@@ -260,6 +262,13 @@ fun Application.module() {
         innsokPaaFellesOppstartService = innsokPaaFellesOppstartService,
     )
 
+    val testdataService = TestdataService(
+        pameldingService = pameldingService,
+        deltakerlisteRepository = deltakerlisteRepository,
+        arrangorMeldingProducer = arrangorMeldingProducer,
+        deltakerService = deltakerService,
+    )
+
     val consumers = listOf(
         ArrangorConsumer(arrangorRepository),
         NavAnsattConsumer(navAnsattService),
@@ -293,6 +302,7 @@ fun Application.module() {
         vurderingService,
         hendelseService,
         endringFraTiltakskoordinatorService,
+        testdataService,
     )
     configureMonitoring()
 

--- a/src/main/kotlin/no/nav/amt/deltaker/application/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/application/plugins/Routing.kt
@@ -11,6 +11,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
+import no.nav.amt.deltaker.Environment
 import no.nav.amt.deltaker.application.registerHealthApi
 import no.nav.amt.deltaker.auth.AuthenticationException
 import no.nav.amt.deltaker.auth.AuthorizationException
@@ -28,6 +29,8 @@ import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducerService
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.hendelse.HendelseService
 import no.nav.amt.deltaker.internal.registerInternalApi
+import no.nav.amt.deltaker.testdata.TestdataService
+import no.nav.amt.deltaker.testdata.registerTestdataApi
 import no.nav.amt.deltaker.tiltakskoordinator.endring.EndringFraTiltakskoordinatorService
 import no.nav.amt.deltaker.tiltakskoordinator.registerTiltakskoordinatorApi
 import no.nav.amt.deltaker.unleash.UnleashToggle
@@ -47,6 +50,7 @@ fun Application.configureRouting(
     vurderingService: VurderingService,
     hendelseService: HendelseService,
     endringFraTiltakskoordinatorService: EndringFraTiltakskoordinatorService,
+    testdataService: TestdataService,
 ) {
     install(StatusPages) {
         exception<IllegalArgumentException> { call, cause ->
@@ -86,6 +90,10 @@ fun Application.configureRouting(
             endringFraTiltakskoordinatorService,
         )
         registerTiltakskoordinatorApi(deltakerService)
+
+        if (!Environment.isProd()) {
+            registerTestdataApi(testdataService)
+        }
 
         val catchAllRoute = "{...}"
         route(catchAllRoute) {

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/forslag/kafka/ArrangorMeldingProducer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/forslag/kafka/ArrangorMeldingProducer.kt
@@ -3,15 +3,12 @@ package no.nav.amt.deltaker.deltaker.forslag.kafka
 import no.nav.amt.deltaker.Environment
 import no.nav.amt.deltaker.application.plugins.objectMapper
 import no.nav.amt.lib.kafka.Producer
-import no.nav.amt.lib.models.arrangor.melding.Forslag
-import org.slf4j.LoggerFactory
+import no.nav.amt.lib.models.arrangor.melding.Melding
 
 class ArrangorMeldingProducer(
     private val producer: Producer<String, String>,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
-    fun produce(forslag: Forslag) {
-        producer.produce(Environment.ARRANGOR_MELDING_TOPIC, forslag.id.toString(), objectMapper.writeValueAsString(forslag))
+    fun produce(melding: Melding) {
+        producer.produce(Environment.ARRANGOR_MELDING_TOPIC, melding.id.toString(), objectMapper.writeValueAsString(melding))
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/testdata/OpprettTestDeltakelseRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/testdata/OpprettTestDeltakelseRequest.kt
@@ -1,0 +1,30 @@
+package no.nav.amt.deltaker.testdata
+
+import java.time.LocalDate
+import java.util.UUID
+
+const val MIN_DAGER_PER_UKE = 1
+const val MAX_DAGER_PER_UKE = 5
+const val MIN_DELTAKELSESPROSENT = 1
+const val MAX_DELTAKELSESPROSENT = 100
+
+data class OpprettTestDeltakelseRequest(
+    val personident: String,
+    val deltakerlisteId: UUID,
+    val startdato: LocalDate,
+    val deltakelsesprosent: Int?,
+    val dagerPerUke: Int?,
+) {
+    fun valider() {
+        dagerPerUke?.let {
+            require(it in MIN_DAGER_PER_UKE..MAX_DAGER_PER_UKE) {
+                "Dager per uke kan ikke være mindre enn $MIN_DAGER_PER_UKE eller større enn $MAX_DAGER_PER_UKE"
+            }
+        }
+        deltakelsesprosent?.let {
+            require(it in MIN_DELTAKELSESPROSENT..MAX_DELTAKELSESPROSENT) {
+                "Deltakelsesprosent kan ikke være mindre enn $MIN_DELTAKELSESPROSENT eller større enn $MAX_DELTAKELSESPROSENT"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/testdata/TestdataApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/testdata/TestdataApi.kt
@@ -1,0 +1,19 @@
+package no.nav.amt.deltaker.testdata
+
+import io.ktor.server.auth.authenticate
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.post
+
+fun Routing.registerTestdataApi(testdataService: TestdataService) {
+    authenticate("SYSTEM") {
+        post("/testdata/opprett") {
+            val request = call.receive<OpprettTestDeltakelseRequest>()
+            request.valider()
+            val deltaker = testdataService.opprettDeltakelse(request)
+
+            call.respond(deltaker)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/testdata/TestdataService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/testdata/TestdataService.kt
@@ -1,0 +1,126 @@
+package no.nav.amt.deltaker.testdata
+
+import kotlinx.coroutines.delay
+import no.nav.amt.deltaker.deltaker.DeltakerService
+import no.nav.amt.deltaker.deltaker.PameldingService
+import no.nav.amt.deltaker.deltaker.api.model.UtkastRequest
+import no.nav.amt.deltaker.deltaker.forslag.kafka.ArrangorMeldingProducer
+import no.nav.amt.deltaker.deltaker.model.Deltaker
+import no.nav.amt.deltaker.deltakerliste.Deltakerliste
+import no.nav.amt.deltaker.deltakerliste.DeltakerlisteRepository
+import no.nav.amt.lib.models.arrangor.melding.EndringFraArrangor
+import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
+import no.nav.amt.lib.models.deltaker.Innhold
+import no.nav.amt.lib.models.deltakerliste.tiltakstype.Innholdselement
+import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+const val TESTVEILEDER = "Z990098"
+const val TESTENHET = "0314"
+
+// Plutselig Lagsport
+const val TESTARRANGORANSATT = "fff9a665-cbde-4dbc-9ef9-deb8681a0d6f"
+
+class TestdataService(
+    private val pameldingService: PameldingService,
+    private val deltakerlisteRepository: DeltakerlisteRepository,
+    private val arrangorMeldingProducer: ArrangorMeldingProducer,
+    private val deltakerService: DeltakerService,
+) {
+    suspend fun opprettDeltakelse(opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest): Deltaker {
+        val deltakerliste = deltakerlisteRepository.get(opprettTestDeltakelseRequest.deltakerlisteId).getOrThrow()
+        val forventetSluttdato = opprettTestDeltakelseRequest.startdato.plusMonths(3)
+        valider(
+            startdato = opprettTestDeltakelseRequest.startdato,
+            sluttdato = forventetSluttdato,
+            deltakerliste = deltakerliste,
+        )
+        val kladd = pameldingService.opprettKladd(
+            deltakerlisteId = opprettTestDeltakelseRequest.deltakerlisteId,
+            personident = opprettTestDeltakelseRequest.personident,
+        )
+        val deltakerId = kladd.id
+
+        delay(10)
+
+        val utkast = getUtkastRequest(deltakerliste, opprettTestDeltakelseRequest)
+        pameldingService.upsertUtkast(
+            deltakerId = deltakerId,
+            utkast = utkast,
+        )
+
+        delay(100)
+
+        val endringFraArrangor = getEndringFraArrangor(
+            deltakerId = deltakerId,
+            startdato = opprettTestDeltakelseRequest.startdato,
+            sluttdato = forventetSluttdato,
+        )
+        arrangorMeldingProducer.produce(endringFraArrangor)
+
+        delay(100)
+
+        return deltakerService.get(deltakerId).getOrThrow()
+    }
+
+    private fun valider(
+        startdato: LocalDate,
+        sluttdato: LocalDate,
+        deltakerliste: Deltakerliste,
+    ) {
+        if (deltakerliste.tiltakstype.tiltakskode != Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING) {
+            throw IllegalArgumentException("Det er kun AFT som er støttet for testdeltakelser inntil videre")
+        }
+        if (startdato.isBefore(deltakerliste.startDato)) {
+            throw IllegalArgumentException("Kan ikke sette startdato tidligere enn gjennomføringens startdato")
+        }
+        if (deltakerliste.sluttDato != null && sluttdato.isAfter(deltakerliste.sluttDato)) {
+            throw IllegalArgumentException("Kan ikke sette sluttdato senere enn gjennomføringens sluttdato")
+        }
+    }
+
+    fun getEndringFraArrangor(
+        deltakerId: UUID,
+        startdato: LocalDate,
+        sluttdato: LocalDate,
+    ): EndringFraArrangor = EndringFraArrangor(
+        id = UUID.randomUUID(),
+        deltakerId = deltakerId,
+        opprettetAvArrangorAnsattId = UUID.fromString(TESTARRANGORANSATT),
+        opprettet = LocalDateTime.now(),
+        endring = EndringFraArrangor.LeggTilOppstartsdato(
+            startdato = startdato,
+            sluttdato = sluttdato,
+        ),
+    )
+
+    private fun getUtkastRequest(deltakerliste: Deltakerliste, opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest): UtkastRequest {
+        return UtkastRequest(
+            deltakelsesinnhold = getInnhold(deltakerliste),
+            bakgrunnsinformasjon = null,
+            deltakelsesprosent = opprettTestDeltakelseRequest.deltakelsesprosent?.toFloat(),
+            dagerPerUke = opprettTestDeltakelseRequest.dagerPerUke?.toFloat(),
+            endretAv = TESTVEILEDER,
+            endretAvEnhet = TESTENHET,
+            godkjentAvNav = true,
+        )
+    }
+
+    private fun getInnhold(deltakerliste: Deltakerliste): Deltakelsesinnhold {
+        val innhold = deltakerliste.tiltakstype.innhold
+        val valgtInnhold = innhold?.innholdselementer?.firstOrNull()?.toInnhold()
+        return Deltakelsesinnhold(
+            ledetekst = innhold?.ledetekst,
+            innhold = valgtInnhold?.let { listOf(it) } ?: emptyList(),
+        )
+    }
+
+    private fun Innholdselement.toInnhold(valgt: Boolean = true, beskrivelse: String? = null) = Innhold(
+        tekst = tekst,
+        innholdskode = innholdskode,
+        valgt = valgt,
+        beskrivelse = beskrivelse,
+    )
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/ApplicationTest.kt
@@ -19,7 +19,21 @@ class ApplicationTest {
         application {
             configureSerialization()
             configureAuthentication(Environment())
-            configureRouting(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+            configureRouting(
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+            )
         }
         client.get("/internal/health/liveness").apply {
             status shouldBe HttpStatusCode.OK

--- a/src/test/kotlin/no/nav/amt/deltaker/application/plugins/AuthenticationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/application/plugins/AuthenticationTest.kt
@@ -120,6 +120,7 @@ class AuthenticationTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
             setUpTestRoute()
         }

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/DeltakerApiTest.kt
@@ -439,6 +439,7 @@ class DeltakerApiTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/HentDeltakelserApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/HentDeltakelserApiTest.kt
@@ -257,6 +257,7 @@ class HentDeltakelserApiTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/PameldingApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/api/PameldingApiTest.kt
@@ -154,6 +154,7 @@ class PameldingApiTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/testdata/TestdataApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/testdata/TestdataApiTest.kt
@@ -1,0 +1,114 @@
+package no.nav.amt.deltaker.testdata
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.amt.deltaker.Environment
+import no.nav.amt.deltaker.application.plugins.configureAuthentication
+import no.nav.amt.deltaker.application.plugins.configureRouting
+import no.nav.amt.deltaker.application.plugins.configureSerialization
+import no.nav.amt.deltaker.application.plugins.objectMapper
+import no.nav.amt.deltaker.deltaker.api.utils.postRequest
+import no.nav.amt.deltaker.utils.configureEnvForAuthentication
+import no.nav.amt.deltaker.utils.data.TestData
+import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+class TestdataApiTest {
+    private val testdataService = mockk<TestdataService>()
+
+    @Before
+    fun setup() {
+        configureEnvForAuthentication()
+    }
+
+    @Test
+    fun `opprett testdata - mangler token - returnerer 401`() = testApplication {
+        setUpTestApplication()
+        client.post("/testdata/opprett") { setBody("foo") }.status shouldBe HttpStatusCode.Unauthorized
+    }
+
+    @Test
+    fun `opprett testdata - har tilgang, ugyldig request - returnerer BadRequest`() = testApplication {
+        val deltakerliste = TestData.lagDeltakerliste(
+            tiltakstype = TestData.lagTiltakstype(tiltakskode = Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+        )
+        val startdato = LocalDate.now().minusDays(1)
+        val opprettTestDeltakelseRequest = OpprettTestDeltakelseRequest(
+            personident = TestData.randomIdent(),
+            deltakerlisteId = deltakerliste.id,
+            startdato = startdato,
+            deltakelsesprosent = 100,
+            dagerPerUke = 7,
+        )
+
+        setUpTestApplication()
+
+        client.post("/testdata/opprett") { postRequest(opprettTestDeltakelseRequest) }.apply {
+            status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
+    fun `opprett testdata - har tilgang, gyldig request - returnerer deltaker`() = testApplication {
+        val deltakerliste = TestData.lagDeltakerliste(
+            tiltakstype = TestData.lagTiltakstype(tiltakskode = Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+        )
+        val startdato = LocalDate.now().minusDays(1)
+        val deltaker = TestData.lagDeltaker(
+            deltakerliste = deltakerliste,
+            startdato = startdato,
+            sluttdato = startdato.plusMonths(3),
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            deltakelsesprosent = 50F,
+            dagerPerUke = 3F,
+        )
+        val opprettTestDeltakelseRequest = OpprettTestDeltakelseRequest(
+            personident = deltaker.navBruker.personident,
+            deltakerlisteId = deltaker.deltakerliste.id,
+            startdato = startdato,
+            deltakelsesprosent = deltaker.deltakelsesprosent?.toInt(),
+            dagerPerUke = deltaker.dagerPerUke?.toInt(),
+        )
+
+        coEvery { testdataService.opprettDeltakelse(any()) } returns deltaker
+
+        setUpTestApplication()
+
+        client.post("/testdata/opprett") { postRequest(opprettTestDeltakelseRequest) }.apply {
+            status shouldBe HttpStatusCode.OK
+            bodyAsText() shouldBe objectMapper.writeValueAsString(deltaker)
+        }
+    }
+
+    private fun ApplicationTestBuilder.setUpTestApplication() {
+        application {
+            configureSerialization()
+            configureAuthentication(Environment())
+            configureRouting(
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                testdataService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/testdata/TestdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/testdata/TestdataServiceTest.kt
@@ -1,0 +1,254 @@
+package no.nav.amt.deltaker.testdata
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.amt.deltaker.application.plugins.objectMapper
+import no.nav.amt.deltaker.arrangor.ArrangorRepository
+import no.nav.amt.deltaker.arrangor.ArrangorService
+import no.nav.amt.deltaker.deltaker.DeltakerHistorikkService
+import no.nav.amt.deltaker.deltaker.DeltakerService
+import no.nav.amt.deltaker.deltaker.PameldingService
+import no.nav.amt.deltaker.deltaker.VedtakService
+import no.nav.amt.deltaker.deltaker.db.DeltakerEndringRepository
+import no.nav.amt.deltaker.deltaker.db.DeltakerRepository
+import no.nav.amt.deltaker.deltaker.db.VedtakRepository
+import no.nav.amt.deltaker.deltaker.endring.DeltakerEndringService
+import no.nav.amt.deltaker.deltaker.endring.fra.arrangor.EndringFraArrangorRepository
+import no.nav.amt.deltaker.deltaker.endring.fra.arrangor.EndringFraArrangorService
+import no.nav.amt.deltaker.deltaker.forslag.ForslagRepository
+import no.nav.amt.deltaker.deltaker.forslag.ForslagService
+import no.nav.amt.deltaker.deltaker.forslag.kafka.ArrangorMeldingConsumer
+import no.nav.amt.deltaker.deltaker.forslag.kafka.ArrangorMeldingProducer
+import no.nav.amt.deltaker.deltaker.importert.fra.arena.ImportertFraArenaRepository
+import no.nav.amt.deltaker.deltaker.innsok.InnsokPaaFellesOppstartRepository
+import no.nav.amt.deltaker.deltaker.innsok.InnsokPaaFellesOppstartService
+import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducer
+import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducerService
+import no.nav.amt.deltaker.deltaker.kafka.DeltakerV1Producer
+import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerDtoMapperService
+import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
+import no.nav.amt.deltaker.deltaker.vurdering.VurderingService
+import no.nav.amt.deltaker.deltakerliste.DeltakerlisteRepository
+import no.nav.amt.deltaker.hendelse.HendelseProducer
+import no.nav.amt.deltaker.hendelse.HendelseService
+import no.nav.amt.deltaker.navansatt.NavAnsatt
+import no.nav.amt.deltaker.navansatt.NavAnsattRepository
+import no.nav.amt.deltaker.navansatt.NavAnsattService
+import no.nav.amt.deltaker.navansatt.navenhet.NavEnhet
+import no.nav.amt.deltaker.navansatt.navenhet.NavEnhetRepository
+import no.nav.amt.deltaker.navansatt.navenhet.NavEnhetService
+import no.nav.amt.deltaker.navbruker.NavBrukerRepository
+import no.nav.amt.deltaker.navbruker.NavBrukerService
+import no.nav.amt.deltaker.navbruker.model.NavBruker
+import no.nav.amt.deltaker.tiltakskoordinator.endring.EndringFraTiltakskoordinatorRepository
+import no.nav.amt.deltaker.unleash.UnleashToggle
+import no.nav.amt.deltaker.utils.MockResponseHandler
+import no.nav.amt.deltaker.utils.data.TestData
+import no.nav.amt.deltaker.utils.data.TestRepository
+import no.nav.amt.deltaker.utils.mockAmtArrangorClient
+import no.nav.amt.deltaker.utils.mockAmtPersonClient
+import no.nav.amt.deltaker.utils.mockIsOppfolgingstilfelleClient
+import no.nav.amt.lib.kafka.Producer
+import no.nav.amt.lib.kafka.config.LocalKafkaConfig
+import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
+import no.nav.amt.lib.testing.SingletonKafkaProvider
+import no.nav.amt.lib.testing.SingletonPostgres16Container
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import java.time.LocalDate
+
+class TestdataServiceTest {
+    companion object {
+        private val navEnhetService = NavEnhetService(NavEnhetRepository(), mockAmtPersonClient())
+        private val navAnsattService = NavAnsattService(NavAnsattRepository(), mockAmtPersonClient(), navEnhetService)
+        private val arrangorService = ArrangorService(ArrangorRepository(), mockAmtArrangorClient())
+        private val isOppfolgingstilfelleClient = mockIsOppfolgingstilfelleClient()
+        private val forslagRepository = ForslagRepository()
+        private val deltakerRepository = DeltakerRepository()
+        private val deltakerEndringRepository = DeltakerEndringRepository()
+        private val endringFraArrangorRepository = EndringFraArrangorRepository()
+        private val vedtakRepository = VedtakRepository()
+        private val importertFraArenaRepository = ImportertFraArenaRepository()
+        private val kafkaProducer = Producer<String, String>(LocalKafkaConfig(SingletonKafkaProvider.getHost()))
+        private val innsokPaaFellesOppstartRepository = InnsokPaaFellesOppstartRepository()
+        private val innsokPaaFellesOppstartService = InnsokPaaFellesOppstartService(innsokPaaFellesOppstartRepository)
+        private val endringFraTiltakskoordinatorRepository = EndringFraTiltakskoordinatorRepository()
+        private val deltakerHistorikkService =
+            DeltakerHistorikkService(
+                deltakerEndringRepository,
+                vedtakRepository,
+                forslagRepository,
+                endringFraArrangorRepository,
+                importertFraArenaRepository,
+                innsokPaaFellesOppstartRepository,
+                endringFraTiltakskoordinatorRepository,
+                vurderingService = VurderingService(VurderingRepository()),
+            )
+        private val hendelseService = HendelseService(
+            HendelseProducer(kafkaProducer),
+            navAnsattService,
+            navEnhetService,
+            arrangorService,
+            deltakerHistorikkService,
+            VurderingService(VurderingRepository()),
+        )
+
+        private val vedtakService = VedtakService(vedtakRepository)
+        private val forslagService = ForslagService(forslagRepository, mockk(), deltakerRepository, mockk())
+        private val endringFraArrangorService = EndringFraArrangorService(
+            endringFraArrangorRepository = endringFraArrangorRepository,
+            hendelseService = hendelseService,
+            deltakerHistorikkService = deltakerHistorikkService,
+        )
+        private val unleashToggle = mockk<UnleashToggle>(relaxed = true)
+        private val deltakerDtoMapperService =
+            DeltakerDtoMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, VurderingRepository())
+        private val deltakerProducer = DeltakerProducer(
+            kafkaProducer,
+        )
+        private val deltakerV1Producer = DeltakerV1Producer(
+            kafkaProducer,
+        )
+        private val deltakerProducerService =
+            DeltakerProducerService(deltakerDtoMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
+
+        private val arrangorMeldingProducer = ArrangorMeldingProducer(kafkaProducer)
+
+        private val deltakerService = DeltakerService(
+            deltakerRepository = deltakerRepository,
+            deltakerProducerService = deltakerProducerService,
+            deltakerEndringService = DeltakerEndringService(
+                deltakerEndringRepository,
+                navAnsattService,
+                navEnhetService,
+                hendelseService,
+                forslagService,
+                deltakerHistorikkService,
+            ),
+            vedtakService = vedtakService,
+            hendelseService = hendelseService,
+            endringFraArrangorService = endringFraArrangorService,
+            forslagService = forslagService,
+            importertFraArenaRepository = importertFraArenaRepository,
+            deltakerHistorikkService = deltakerHistorikkService,
+            unleashToggle = unleashToggle,
+            endringFraTiltakskoordinatorService = mockk(),
+            navAnsattService = navAnsattService,
+            endringFraTiltakskoordinatorRepository = endringFraTiltakskoordinatorRepository,
+            navEnhetService = navEnhetService,
+        )
+
+        private val deltakerlisteRepository = DeltakerlisteRepository()
+
+        private var pameldingService = PameldingService(
+            deltakerService = deltakerService,
+            deltakerlisteRepository = deltakerlisteRepository,
+            navBrukerService = NavBrukerService(
+                NavBrukerRepository(),
+                mockAmtPersonClient(),
+                navEnhetService,
+                navAnsattService,
+            ),
+            navAnsattService = navAnsattService,
+            navEnhetService = navEnhetService,
+            vedtakService = vedtakService,
+            isOppfolgingstilfelleClient = isOppfolgingstilfelleClient,
+            hendelseService,
+            innsokPaaFellesOppstartService,
+        )
+
+        private val testdataService = TestdataService(
+            pameldingService = pameldingService,
+            deltakerlisteRepository = deltakerlisteRepository,
+            arrangorMeldingProducer = arrangorMeldingProducer,
+            deltakerService = deltakerService,
+        )
+
+        val arrangorMeldingConsumer = ArrangorMeldingConsumer(
+            forslagService = forslagService,
+            deltakerService = deltakerService,
+            vurderingService = mockk(),
+            unleashToggle = unleashToggle,
+            deltakerProducerService = deltakerProducerService,
+        )
+
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+            SingletonPostgres16Container
+        }
+    }
+
+    @Before
+    fun cleanDatabase() {
+        TestRepository.cleanDatabase()
+        every { unleashToggle.erKometMasterForTiltakstype(any()) } returns true
+    }
+
+    @Test
+    fun `opprettDeltakelse - deltaker finnes ikke, gyldig request - oppretter ny deltaker`() {
+        val arrangor = TestData.lagArrangor()
+        val deltakerliste = TestData.lagDeltakerliste(
+            arrangor = arrangor,
+            tiltakstype = TestData.lagTiltakstype(tiltakskode = Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+        )
+        val opprettetAv = TestData.lagNavAnsatt(navIdent = TESTVEILEDER)
+        val opprettetAvEnhet = TestData.lagNavEnhet(enhetsnummer = TESTENHET)
+        TestRepository.insert(opprettetAv)
+        TestRepository.insert(opprettetAv)
+        val navBruker = TestData.lagNavBruker(navVeilederId = opprettetAv.id, navEnhetId = opprettetAvEnhet.id)
+
+        mockResponses(opprettetAvEnhet, opprettetAv, navBruker)
+        TestRepository.insert(deltakerliste)
+
+        val opprettTestDeltakelseRequest = OpprettTestDeltakelseRequest(
+            personident = navBruker.personident,
+            deltakerlisteId = deltakerliste.id,
+            startdato = LocalDate.now().minusDays(1),
+            deltakelsesprosent = 60,
+            dagerPerUke = 3,
+        )
+
+        runBlocking {
+            val deltaker = testdataService.opprettDeltakelse(opprettTestDeltakelseRequest)
+
+            arrangorMeldingConsumer.consume(
+                deltaker.id,
+                objectMapper.writeValueAsString(
+                    testdataService.getEndringFraArrangor(
+                        deltaker.id,
+                        opprettTestDeltakelseRequest.startdato,
+                        opprettTestDeltakelseRequest.startdato.plusMonths(3),
+                    ),
+                ),
+            )
+
+            val deltakerFraDb = deltakerService.getDeltakelserForPerson(navBruker.personident, deltakerliste.id).first()
+            deltakerFraDb.id shouldBe deltaker.id
+            deltakerFraDb.deltakerliste.id shouldBe deltakerliste.id
+            deltakerFraDb.status.type shouldBe DeltakerStatus.Type.DELTAR
+            deltakerFraDb.startdato shouldBe opprettTestDeltakelseRequest.startdato
+            deltakerFraDb.sluttdato shouldBe opprettTestDeltakelseRequest.startdato.plusMonths(3)
+            deltakerFraDb.dagerPerUke shouldBe opprettTestDeltakelseRequest.dagerPerUke?.toFloat()
+            deltakerFraDb.deltakelsesprosent shouldBe opprettTestDeltakelseRequest.deltakelsesprosent?.toFloat()
+            deltakerFraDb.bakgrunnsinformasjon shouldBe null
+            deltakerFraDb.deltakelsesinnhold?.ledetekst shouldBe deltakerliste.tiltakstype.innhold!!.ledetekst
+            deltakerFraDb.deltakelsesinnhold?.innhold?.size shouldBe 1
+        }
+    }
+
+    private fun mockResponses(
+        navEnhet: NavEnhet,
+        navAnsatt: NavAnsatt,
+        navBruker: NavBruker,
+    ) {
+        navAnsatt.navEnhetId?.let { MockResponseHandler.addNavEnhetGetResponse(TestData.lagNavEnhet(it)) }
+        MockResponseHandler.addNavEnhetResponse(navEnhet)
+        MockResponseHandler.addNavAnsattResponse(navAnsatt)
+        MockResponseHandler.addNavBrukerResponse(navBruker)
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/tiltakskoordinator/TiltakskoordinatorApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/tiltakskoordinator/TiltakskoordinatorApiTest.kt
@@ -115,6 +115,7 @@ class TiltakskoordinatorApiTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
     }


### PR DESCRIPTION
Nytt api for å opprette testdeltakelser i dev. Kun tilgjengelig for AFT. Krever systemtoken. Jeg har ikke gitt tilgang til noen apper ennå siden vi ikke helt vet hvilken app hos oss som skal bruke dette :)

Delay-ene ligger der for å gi appen litt tid til å produsere hendelser i riktig rekkefølge, og får at vi kanskje skal få inn oppstartsdato via topic. 