### PR TITLE
Bump dependencies - 20250708105322

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     kotlin("jvm") version kotlinVersion
     id("io.ktor.plugin") version "3.2.1"
     id("org.jetbrains.kotlin.plugin.serialization") version kotlinVersion
-    id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
+    id("org.jlleitschuh.gradle.ktlint") version "13.0.0"
     id("com.gradleup.shadow") version "8.3.8"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ val postgresVersion = "42.7.7"
 val caffeineVersion = "3.2.1"
 val mockkVersion = "1.14.4"
 val nimbusVersion = "10.3.1"
-val unleashVersion = "11.0.1"
+val unleashVersion = "11.0.2"
 val amtLibVersion = "1.2025.06.30_11.34-39810db912fa"
 val awaitilityVersion = "4.3.0"
 


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250708105322 branch:

## Successfully Rebased PRs
- [Bump org.jlleitschuh.gradle.ktlint from 12.3.0 to 13.0.0](https://github.com/navikt/amt-deltaker/pull/477)
- [Bump io.getunleash:unleash-client-java from 11.0.1 to 11.0.2](https://github.com/navikt/amt-deltaker/pull/475)


