### PR TITLE
Fjernet kotlinVersion = "2.1.0" fordi den ikke stemmer overens med pl…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ repositories {
     maven { setUrl("https://github-package-registry-mirror.gc.nav.no/cached/maven-release") }
 }
 
-val kotlinVersion = "2.1.0"
 val ktorVersion = "3.2.1"
 val logbackVersion = "1.5.18"
 val prometeusVersion = "1.15.1"
@@ -81,7 +80,7 @@ dependencies {
 
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-json-jvm:$kotestVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")


### PR DESCRIPTION
…ugin-versjon 2.2.0

`org.jetbrains.kotlin:kotlin-test-junit5` vil benytte Kotlin-versjon fra plugin, og trenger derfor ikke versjon.

Dette kan verifiseres med følgende kommando:
```
 ./gradlew dependencies | grep junit5
```