### PR TITLE
Gjenopprett replication slot etter oppgradering av postgres

### DIFF
--- a/src/main/resources/db/migration/V37__recreate-replication-slot.sql
+++ b/src/main/resources/db/migration/V37__recreate-replication-slot.sql
@@ -1,0 +1,9 @@
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_replication_slots WHERE slot_name = 'amt_deltaker_replication'
+        ) THEN
+            PERFORM PG_CREATE_LOGICAL_REPLICATION_SLOT('amt_deltaker_replication', 'pgoutput');
+        END IF;
+    END;
+$$;


### PR DESCRIPTION
Når major versjoner av databaser oppgraderes så må man gjenopprette replication slot. Datastreamene vår er avhengige av disse, og må restartes etter en slik oppgradering.