### PR TITLE
Fix for clock-skew issues mellom app og database for deltaker_status-tabellen

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DbUtils.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DbUtils.kt
@@ -1,0 +1,31 @@
+package no.nav.amt.deltaker.deltaker.db
+
+import java.time.Duration
+import java.time.LocalDateTime
+
+object DbUtils {
+    /**
+     * Returnerer `null` dersom [dateTime] er "nær nok" nåværende tidspunkt, ellers returneres
+     * den opprinnelige verdien.
+     *
+     * Brukes for å signalisere at en tidsverdi kan erstattes med `CURRENT_TIMESTAMP`
+     * i databasen, i stedet for å sette tidspunktet eksplisitt fra applikasjonen.
+     *
+     * "Nær nok" defineres som at differansen mellom [dateTime] og [LocalDateTime.now()]
+     * er mindre enn eller lik [graceInSeconds] sekunder.
+     *
+     * @param dateTime tidspunktet som skal vurderes.
+     * @param graceInSeconds antall sekunder tidsforskjellen kan være for å anses som "nær nå".
+     *                       Standard er 5 sekunder.
+     * @return `null` dersom tidspunktet er innenfor gitt toleranse fra nå,
+     *         ellers [dateTime].
+     */
+    fun nullWhenNearNow(dateTime: LocalDateTime, graceInSeconds: Long = 5): LocalDateTime? = if (Duration
+            .between(dateTime, LocalDateTime.now())
+            .abs() <= Duration.ofSeconds(graceInSeconds)
+    ) {
+        null
+    } else {
+        dateTime
+    }
+}


### PR DESCRIPTION
Denne PR-en forsøker å fikse at det kan være clock-skew mellom app og database, noe som medfører at select fra deltaker etter inserts i deltaker og deltaker_status feiler grunnet datobeskrankinger i get-spørring. 

Denne PR-en vil mest sannsynlig også fikse flaky tester.