### PR TITLE
Bruker ny lib versjon av DeltakerPayload

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ val caffeineVersion = "3.2.2"
 val mockkVersion = "1.14.5"
 val nimbusVersion = "10.5"
 val unleashVersion = "11.1.0"
-val amtLibVersion = "1.2025.10.01_11.29-8da7435c10c1"
+val amtLibVersion = "1.2025.10.06_07.30-5449cbb4e0bb"
 
 dependencies {
     implementation("io.ktor:ktor-server-content-negotiation-jvm")

--- a/src/main/kotlin/no/nav/amt/deltaker/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/Application.kt
@@ -49,7 +49,7 @@ import no.nav.amt.deltaker.deltaker.kafka.DeltakerConsumer
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducer
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducerService
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerV1Producer
-import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerDtoMapperService
+import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerKafkaPayloadMapperService
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.deltakerliste.DeltakerlisteRepository
@@ -222,11 +222,12 @@ fun Application.module() {
     )
     val unleashToggle = UnleashToggle(unleash)
 
-    val deltakerDtoMapperService =
-        DeltakerDtoMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, vurderingRepository)
+    val deltakerKafkaPayloadMapperService =
+        DeltakerKafkaPayloadMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, vurderingRepository)
     val deltakerProducer = DeltakerProducer(kafkaProducer)
     val deltakerV1Producer = DeltakerV1Producer(kafkaProducer)
-    val deltakerProducerService = DeltakerProducerService(deltakerDtoMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
+    val deltakerProducerService =
+        DeltakerProducerService(deltakerKafkaPayloadMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
 
     val forslagService =
         ForslagService(forslagRepository, ArrangorMeldingProducer(kafkaProducer), deltakerRepository, deltakerProducerService)

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/DeltakerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/DeltakerService.kt
@@ -14,7 +14,6 @@ import no.nav.amt.deltaker.deltaker.forslag.ForslagService
 import no.nav.amt.deltaker.deltaker.importert.fra.arena.ImportertFraArenaRepository
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducerService
 import no.nav.amt.deltaker.deltaker.model.Deltaker
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.hendelse.HendelseService
 import no.nav.amt.deltaker.job.DeltakerProgresjon
@@ -26,6 +25,7 @@ import no.nav.amt.deltaker.unleash.UnleashToggle
 import no.nav.amt.lib.models.arrangor.melding.EndringFraArrangor
 import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.deltaker.internalapis.deltaker.request.EndringRequest
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.ArenaKode
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/PameldingService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/PameldingService.kt
@@ -5,7 +5,6 @@ import no.nav.amt.deltaker.deltaker.extensions.getVedtakOrThrow
 import no.nav.amt.deltaker.deltaker.extensions.tilVedtaksInformasjon
 import no.nav.amt.deltaker.deltaker.innsok.InnsokPaaFellesOppstartService
 import no.nav.amt.deltaker.deltaker.model.Deltaker
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.hendelse.HendelseService
@@ -14,6 +13,7 @@ import no.nav.amt.deltaker.navbruker.NavBrukerService
 import no.nav.amt.deltaker.navenhet.NavEnhetService
 import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.deltaker.internalapis.paamelding.request.AvbrytUtkastRequest
 import no.nav.amt.lib.models.deltaker.internalapis.paamelding.request.UtkastRequest
 import no.nav.amt.lib.models.hendelse.HendelseType

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/db/DeltakerRepository.kt
@@ -8,13 +8,13 @@ import kotliquery.queryOf
 import no.nav.amt.deltaker.deltaker.db.DbUtils.nullWhenNearNow
 import no.nav.amt.deltaker.deltaker.model.AVSLUTTENDE_STATUSER
 import no.nav.amt.deltaker.deltaker.model.Deltaker
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltaker.model.Vedtaksinformasjon
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.utils.toPGObject
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import no.nav.amt.lib.models.deltaker.Innsatsgruppe
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.ArenaKode
 import no.nav.amt.lib.models.person.NavBruker
 import no.nav.amt.lib.models.person.address.Adressebeskyttelse

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumer.kt
@@ -8,7 +8,6 @@ import no.nav.amt.deltaker.deltaker.extensions.toVurdering
 import no.nav.amt.deltaker.deltaker.importert.fra.arena.ImportertFraArenaRepository
 import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerV2Dto
 import no.nav.amt.deltaker.deltaker.model.Deltaker
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltaker.vurdering.Vurdering
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
@@ -20,6 +19,7 @@ import no.nav.amt.lib.kafka.Consumer
 import no.nav.amt.lib.models.deltaker.DeltakerEndring
 import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
 import no.nav.amt.lib.models.deltaker.ImportertFraArena
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.utils.objectMapper
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
@@ -53,6 +53,7 @@ class DeltakerConsumer(
     }
 
     private suspend fun processDeltaker(deltakerV2: DeltakerV2Dto) {
+        return // Denne consumeren skal slettes men beholder den fordi det er noe kode her som skal gjenbrukes i ny consumer
         val deltakerliste = deltakerlisteRepository.get(deltakerV2.deltakerlisteId).getOrThrow()
         if (unleashToggle.erKometMasterForTiltakstype(deltakerliste.tiltakstype.arenaKode)) return
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerProducer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerProducer.kt
@@ -1,8 +1,8 @@
 package no.nav.amt.deltaker.deltaker.kafka
 
 import no.nav.amt.deltaker.Environment
-import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerV2Dto
 import no.nav.amt.lib.kafka.Producer
+import no.nav.amt.lib.models.deltaker.DeltakerKafkaPayload
 import no.nav.amt.lib.utils.objectMapper
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -12,7 +12,7 @@ class DeltakerProducer(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun produce(deltakerV2Dto: DeltakerV2Dto) {
+    fun produce(deltakerV2Dto: DeltakerKafkaPayload) {
         producer.produce(Environment.DELTAKER_V2_TOPIC, deltakerV2Dto.id.toString(), objectMapper.writeValueAsString(deltakerV2Dto))
     }
 

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerProducerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerProducerService.kt
@@ -1,13 +1,13 @@
 package no.nav.amt.deltaker.deltaker.kafka
 
-import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerDtoMapperService
+import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerKafkaPayloadMapperService
 import no.nav.amt.deltaker.deltaker.model.Deltaker
 import no.nav.amt.deltaker.unleash.UnleashToggle
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import java.util.UUID
 
 class DeltakerProducerService(
-    private val deltakerDtoMapperService: DeltakerDtoMapperService,
+    private val deltakerKafkaPayloadMapperService: DeltakerKafkaPayloadMapperService,
     private val deltakerProducer: DeltakerProducer,
     private val deltakerV1Producer: DeltakerV1Producer,
     private val unleashToggle: UnleashToggle,
@@ -18,12 +18,12 @@ class DeltakerProducerService(
         publiserTilDeltakerV1: Boolean = true,
     ) {
         if (deltaker.status.type == DeltakerStatus.Type.KLADD) return
-        val deltakerDto = deltakerDtoMapperService.tilDeltakerDto(deltaker, forcedUpdate)
+        val deltakerPayload = deltakerKafkaPayloadMapperService.tilDeltakerPayload(deltaker, forcedUpdate)
 
         if (unleashToggle.erKometMasterForTiltakstype(deltaker.deltakerliste.tiltakstype.arenaKode)) {
-            deltakerProducer.produce(deltakerDto.v2)
+            deltakerProducer.produce(deltakerPayload.v2)
             if (publiserTilDeltakerV1) {
-                deltakerV1Producer.produce(deltakerDto.v1)
+                deltakerV1Producer.produce(deltakerPayload.v1)
             }
         }
     }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerKafkaPayloadMapperService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerKafkaPayloadMapperService.kt
@@ -2,19 +2,19 @@ package no.nav.amt.deltaker.deltaker.kafka.dto
 
 import no.nav.amt.deltaker.deltaker.DeltakerHistorikkService
 import no.nav.amt.deltaker.deltaker.model.Deltaker
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
 import no.nav.amt.deltaker.navansatt.NavAnsattService
 import no.nav.amt.deltaker.navenhet.NavEnhetService
 import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
+import no.nav.amt.lib.models.deltaker.Kilde
 
-class DeltakerDtoMapperService(
+class DeltakerKafkaPayloadMapperService(
     private val navAnsattService: NavAnsattService,
     private val navEnhetService: NavEnhetService,
     private val deltakerHistorikkService: DeltakerHistorikkService,
     private val vurderingRepository: VurderingRepository,
 ) {
-    suspend fun tilDeltakerDto(deltaker: Deltaker, forcedUpdate: Boolean? = false): DeltakerDto {
+    suspend fun tilDeltakerPayload(deltaker: Deltaker, forcedUpdate: Boolean? = false): DeltakerKafkaPayloadBuilder {
         val deltakerhistorikk = deltakerHistorikkService.getForDeltaker(deltaker.id)
         val vurderinger = vurderingRepository.getForDeltaker(deltaker.id)
 
@@ -33,7 +33,7 @@ class DeltakerDtoMapperService(
         val navAnsatt = deltaker.navBruker.navVeilederId
             ?.let { navAnsattService.hentEllerOpprettNavAnsatt(it) }
 
-        return DeltakerDto(
+        return DeltakerKafkaPayloadBuilder(
             deltaker,
             deltakerhistorikk,
             vurderinger,

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerV1Dto.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerV1Dto.kt
@@ -1,7 +1,7 @@
 package no.nav.amt.deltaker.deltaker.kafka.dto
 
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltaker.Kilde
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerV2Dto.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerV2Dto.kt
@@ -1,12 +1,11 @@
 package no.nav.amt.deltaker.deltaker.kafka.dto
 
 import no.nav.amt.deltaker.deltaker.extensions.toDeltakerstatusArsak
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.lib.models.arrangor.melding.Vurdering
 import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
 import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
-import no.nav.amt.lib.models.person.NavAnsatt
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.person.Oppfolgingsperiode
 import no.nav.amt.lib.models.person.address.Adresse
 import no.nav.amt.lib.models.person.address.Adressebeskyttelse
@@ -14,6 +13,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
+// Skal slettes
 data class DeltakerV2Dto(
     val id: UUID,
     val deltakerlisteId: UUID,
@@ -84,16 +84,5 @@ data class DeltakerV2Dto(
         val navn: String,
         val epost: String?,
         val telefonnummer: String?,
-    ) {
-        companion object {
-            fun fromNavAnsatt(navAnsatt: NavAnsatt) = with(navAnsatt) {
-                DeltakerNavVeilederDto(
-                    id = id,
-                    navn = navn,
-                    epost = epost,
-                    telefonnummer = telefon,
-                )
-            }
-        }
-    }
+    )
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/Deltaker.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/Deltaker.kt
@@ -7,6 +7,7 @@ import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import no.nav.amt.lib.models.deltaker.DeltakerVedImport
 import no.nav.amt.lib.models.deltaker.DeltakerVedVedtak
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.person.NavBruker
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/Kilde.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltaker/model/Kilde.kt
@@ -1,6 +1,0 @@
-package no.nav.amt.deltaker.deltaker.model
-
-enum class Kilde {
-    KOMET,
-    ARENA,
-}

--- a/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/Deltakerliste.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/Deltakerliste.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.deltaker.deltakerliste
 
 import no.nav.amt.lib.models.deltaker.Arrangor
+import no.nav.amt.lib.models.deltakerliste.Oppstartstype
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
 import java.time.LocalDate
 import java.util.UUID
@@ -16,11 +17,6 @@ data class Deltakerliste(
     val apentForPamelding: Boolean,
     val arrangor: Arrangor,
 ) {
-    enum class Oppstartstype {
-        LOPENDE,
-        FELLES,
-    }
-
     enum class Status {
         GJENNOMFORES,
         AVBRUTT,

--- a/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/DeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/DeltakerlisteRepository.kt
@@ -5,6 +5,7 @@ import kotliquery.queryOf
 import no.nav.amt.deltaker.deltakerliste.tiltakstype.TiltakstypeRepository
 import no.nav.amt.deltaker.utils.prefixColumn
 import no.nav.amt.lib.models.deltaker.Arrangor
+import no.nav.amt.lib.models.deltakerliste.Oppstartstype
 import no.nav.amt.lib.utils.database.Database
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -23,7 +24,7 @@ class DeltakerlisteRepository {
                 status = Deltakerliste.Status.valueOf(row.string(col("status"))),
                 startDato = row.localDate(col("start_dato")),
                 sluttDato = row.localDateOrNull(col("slutt_dato")),
-                oppstart = Deltakerliste.Oppstartstype.valueOf(row.string(col("oppstart"))),
+                oppstart = Oppstartstype.valueOf(row.string(col("oppstart"))),
                 apentForPamelding = row.boolean(col("apent_for_pamelding")),
                 arrangor = Arrangor(
                     id = row.uuid("a.id"),

--- a/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/kafka/DeltakerlisteDto.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/deltakerliste/kafka/DeltakerlisteDto.kt
@@ -2,6 +2,7 @@ package no.nav.amt.deltaker.deltakerliste.kafka
 
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
 import no.nav.amt.lib.models.deltaker.Arrangor
+import no.nav.amt.lib.models.deltakerliste.Oppstartstype
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakskode
 import java.time.LocalDate
 import java.util.UUID
@@ -14,7 +15,7 @@ data class DeltakerlisteDto(
     val sluttDato: LocalDate? = null,
     val status: String,
     val virksomhetsnummer: String,
-    val oppstart: Deltakerliste.Oppstartstype,
+    val oppstart: Oppstartstype,
     val apentForPamelding: Boolean?,
 ) {
     data class Tiltakstype(

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/DeltakerServiceTest.kt
@@ -23,7 +23,7 @@ import no.nav.amt.deltaker.deltaker.innsok.InnsokPaaFellesOppstartRepository
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducer
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducerService
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerV1Producer
-import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerDtoMapperService
+import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerKafkaPayloadMapperService
 import no.nav.amt.deltaker.deltaker.model.Deltaker
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingService
@@ -108,8 +108,8 @@ class DeltakerServiceTest {
             vurderingService,
         )
         private val unleashToggle = mockk<UnleashToggle>()
-        private val deltakerDtoMapperService =
-            DeltakerDtoMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, vurderingRepository)
+        private val deltakerKafkaPayloadMapperService =
+            DeltakerKafkaPayloadMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, vurderingRepository)
         private val deltakerProducer = DeltakerProducer(
             kafkaProducer,
         )
@@ -117,7 +117,7 @@ class DeltakerServiceTest {
             kafkaProducer,
         )
         private val deltakerProducerService =
-            DeltakerProducerService(deltakerDtoMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
+            DeltakerProducerService(deltakerKafkaPayloadMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
         private val forslagService = ForslagService(
             forslagRepository,
             ArrangorMeldingProducer(kafkaProducer),

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/PameldingServiceTest.kt
@@ -25,7 +25,7 @@ import no.nav.amt.deltaker.deltaker.innsok.InnsokPaaFellesOppstartService
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducer
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducerService
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerV1Producer
-import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerDtoMapperService
+import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerKafkaPayloadMapperService
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.deltakerliste.DeltakerlisteRepository
@@ -521,14 +521,14 @@ class PameldingServiceTest {
             deltakerHistorikkService = deltakerHistorikkService,
         )
         private val unleashToggle = mockk<UnleashToggle>(relaxed = true)
-        private val deltakerDtoMapperService =
-            DeltakerDtoMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, VurderingRepository())
+        private val deltakerKafkaPayloadMapperService =
+            DeltakerKafkaPayloadMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, VurderingRepository())
 
         private val deltakerProducer = DeltakerProducer(kafkaProducer)
         private val deltakerV1Producer = DeltakerV1Producer(kafkaProducer)
 
         private val deltakerProducerService =
-            DeltakerProducerService(deltakerDtoMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
+            DeltakerProducerService(deltakerKafkaPayloadMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
 
         private val deltakerService = DeltakerService(
             deltakerRepository = deltakerRepository,

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/DeltakerConsumerTest.kt
@@ -17,7 +17,6 @@ import no.nav.amt.deltaker.deltaker.endring.fra.arrangor.EndringFraArrangorRepos
 import no.nav.amt.deltaker.deltaker.forslag.ForslagRepository
 import no.nav.amt.deltaker.deltaker.importert.fra.arena.ImportertFraArenaRepository
 import no.nav.amt.deltaker.deltaker.innsok.InnsokPaaFellesOppstartRepository
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltaker.sammenlignHistorikk
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingService
@@ -38,6 +37,7 @@ import no.nav.amt.lib.ktor.clients.AmtPersonServiceClient
 import no.nav.amt.lib.models.deltaker.DeltakerHistorikk
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import no.nav.amt.lib.models.deltaker.ImportertFraArena
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.ArenaKode
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakskode
 import no.nav.amt.lib.testing.SingletonPostgres16Container
@@ -45,11 +45,13 @@ import no.nav.amt.lib.testing.shouldBeCloseTo
 import no.nav.amt.lib.utils.objectMapper
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.time.Duration.Companion.seconds
 
+@Disabled("Skal slettes/flyttes til en annen consumer")
 class DeltakerConsumerTest {
     companion object {
         lateinit var deltakerRepository: DeltakerRepository

--- a/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerResponseTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/deltaker/kafka/dto/DeltakerResponseTest.kt
@@ -20,7 +20,7 @@ import java.time.LocalDate
 class DeltakerResponseTest {
     @Test
     fun `DeltakerDto - deltaker med deltakelsesmengder - v1 har deltakelsesmengder`(): Unit = with(DeltakerContext()) {
-        deltakerDto.v1.deltakelsesmengder shouldBe historikk.toDeltakelsesmengder().map {
+        deltakerKafkaPayload.v1.deltakelsesmengder shouldBe historikk.toDeltakelsesmengder().map {
             DeltakerV1Dto.DeltakelsesmengdeDto(
                 it.deltakelsesprosent,
                 it.dagerPerUke,
@@ -41,7 +41,7 @@ class DeltakerResponseTest {
                     )
                 }.forEach {
                     withTiltakstype(it)
-                    deltakerDto.v1.deltakelsesmengder shouldBe emptyList()
+                    deltakerKafkaPayload.v1.deltakelsesmengder shouldBe emptyList()
                 }
         }
 
@@ -50,7 +50,7 @@ class DeltakerResponseTest {
         val nyStartdato = deltaker.startdato!!.plusMonths(1)
         withStartdato(nyStartdato)
 
-        deltakerDto.v1.deltakelsesmengder
+        deltakerKafkaPayload.v1.deltakelsesmengder
             .first()
             .gyldigFra shouldBe nyStartdato
     }
@@ -85,8 +85,8 @@ data class DeltakerContext(
         TestRepository.insert(navEnhet)
     }
 
-    val deltakerDto
-        get() = DeltakerDto(
+    val deltakerKafkaPayload
+        get() = DeltakerKafkaPayloadBuilder(
             deltaker,
             historikk,
             vurderinger,

--- a/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/job/DeltakerStatusOppdateringTest.kt
@@ -22,8 +22,7 @@ import no.nav.amt.deltaker.deltaker.innsok.InnsokPaaFellesOppstartRepository
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducer
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerProducerService
 import no.nav.amt.deltaker.deltaker.kafka.DeltakerV1Producer
-import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerDtoMapperService
-import no.nav.amt.deltaker.deltaker.model.Kilde
+import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerKafkaPayloadMapperService
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingRepository
 import no.nav.amt.deltaker.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
@@ -44,6 +43,8 @@ import no.nav.amt.deltaker.utils.mockPersonServiceClient
 import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltaker.Kilde
+import no.nav.amt.lib.models.deltakerliste.Oppstartstype
 import no.nav.amt.lib.models.hendelse.HendelseType
 import no.nav.amt.lib.testing.SingletonKafkaProvider
 import no.nav.amt.lib.testing.SingletonPostgres16Container
@@ -79,12 +80,12 @@ class DeltakerStatusOppdateringTest {
             )
         private val vurderingRepository = VurderingRepository()
         private val unleashToggle = mockk<UnleashToggle>()
-        private val deltakerDtoMapperService =
-            DeltakerDtoMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, vurderingRepository)
+        private val deltakerKafkaPayloadMapperService =
+            DeltakerKafkaPayloadMapperService(navAnsattService, navEnhetService, deltakerHistorikkService, vurderingRepository)
         private val deltakerProducer = DeltakerProducer(kafkaProducer)
         private val deltakerV1Producer = DeltakerV1Producer(kafkaProducer)
         private val deltakerProducerService =
-            DeltakerProducerService(deltakerDtoMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
+            DeltakerProducerService(deltakerKafkaPayloadMapperService, deltakerProducer, deltakerV1Producer, unleashToggle)
         private val arrangorService = ArrangorService(ArrangorRepository(), mockAmtArrangorClient())
         private val vurderingService = VurderingService(vurderingRepository)
         private val hendelseService = HendelseService(
@@ -219,7 +220,7 @@ class DeltakerStatusOppdateringTest {
             startdato = LocalDate.now().minusWeeks(1),
             sluttdato = LocalDate.now().minusDays(2),
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+                oppstart = Oppstartstype.LOPENDE,
                 sluttDato = LocalDate.now().plusMonths(3),
             ),
         )
@@ -252,7 +253,7 @@ class DeltakerStatusOppdateringTest {
             startdato = LocalDate.now().minusWeeks(1),
             sluttdato = LocalDate.now().minusDays(2),
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+                oppstart = Oppstartstype.LOPENDE,
                 sluttDato = LocalDate.now().plusMonths(3),
             ),
         )
@@ -293,7 +294,7 @@ class DeltakerStatusOppdateringTest {
             startdato = LocalDate.now().minusWeeks(1),
             sluttdato = LocalDate.now().minusDays(2),
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.FELLES,
+                oppstart = Oppstartstype.FELLES,
                 sluttDato = LocalDate.now().minusDays(2),
             ),
         )
@@ -326,7 +327,7 @@ class DeltakerStatusOppdateringTest {
             startdato = LocalDate.now().minusWeeks(1),
             sluttdato = LocalDate.now().minusDays(2),
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.FELLES,
+                oppstart = Oppstartstype.FELLES,
                 sluttDato = LocalDate.now().plusDays(2),
             ),
         )
@@ -359,7 +360,7 @@ class DeltakerStatusOppdateringTest {
             startdato = LocalDate.now().minusMonths(1),
             sluttdato = LocalDate.now().plusDays(2),
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+                oppstart = Oppstartstype.LOPENDE,
                 sluttDato = LocalDate.now().minusDays(2),
                 status = Deltakerliste.Status.AVSLUTTET,
             ),
@@ -394,7 +395,7 @@ class DeltakerStatusOppdateringTest {
             startdato = null,
             sluttdato = null,
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+                oppstart = Oppstartstype.LOPENDE,
                 sluttDato = LocalDate.now().minusDays(2),
                 status = Deltakerliste.Status.AVSLUTTET,
             ),
@@ -429,7 +430,7 @@ class DeltakerStatusOppdateringTest {
             startdato = LocalDate.now().minusMonths(1),
             sluttdato = LocalDate.now().plusDays(2),
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+                oppstart = Oppstartstype.LOPENDE,
                 sluttDato = LocalDate.now().minusDays(2),
                 status = Deltakerliste.Status.AVLYST,
             ),
@@ -464,7 +465,7 @@ class DeltakerStatusOppdateringTest {
             startdato = null,
             sluttdato = null,
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+                oppstart = Oppstartstype.LOPENDE,
                 sluttDato = LocalDate.now().minusDays(2),
                 status = Deltakerliste.Status.AVBRUTT,
             ),
@@ -499,7 +500,7 @@ class DeltakerStatusOppdateringTest {
             startdato = null,
             sluttdato = null,
             deltakerliste = TestData.lagDeltakerliste(
-                oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+                oppstart = Oppstartstype.LOPENDE,
                 sluttDato = LocalDate.now().minusDays(2),
                 status = Deltakerliste.Status.AVBRUTT,
             ),
@@ -530,7 +531,7 @@ class DeltakerStatusOppdateringTest {
         TestRepository.insert(sistEndretAv)
         TestRepository.insert(sistEndretAvEnhet)
         val deltakerliste = TestData.lagDeltakerliste(
-            oppstart = Deltakerliste.Oppstartstype.LOPENDE,
+            oppstart = Oppstartstype.LOPENDE,
             sluttDato = LocalDate.now().minusDays(2),
             status = Deltakerliste.Status.AVLYST,
         )

--- a/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/utils/data/TestData.kt
@@ -2,7 +2,6 @@ package no.nav.amt.deltaker.utils.data
 
 import no.nav.amt.deltaker.deltaker.kafka.dto.DeltakerV2Dto
 import no.nav.amt.deltaker.deltaker.model.Deltaker
-import no.nav.amt.deltaker.deltaker.model.Kilde
 import no.nav.amt.deltaker.deltaker.model.Vedtaksinformasjon
 import no.nav.amt.deltaker.deltaker.vurdering.Vurdering
 import no.nav.amt.deltaker.deltakerliste.Deltakerliste
@@ -19,7 +18,9 @@ import no.nav.amt.lib.models.deltaker.DeltakerVedImport
 import no.nav.amt.lib.models.deltaker.ImportertFraArena
 import no.nav.amt.lib.models.deltaker.Innsatsgruppe
 import no.nav.amt.lib.models.deltaker.InnsokPaaFellesOppstart
+import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.deltaker.Vedtak
+import no.nav.amt.lib.models.deltakerliste.Oppstartstype
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.ArenaKode
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.DeltakerRegistreringInnhold
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Innholdselement
@@ -145,7 +146,7 @@ object TestData {
         status: Deltakerliste.Status = Deltakerliste.Status.GJENNOMFORES,
         startDato: LocalDate = LocalDate.now().minusMonths(1),
         sluttDato: LocalDate? = LocalDate.now().plusYears(1),
-        oppstart: Deltakerliste.Oppstartstype = finnOppstartstype(tiltakstype.arenaKode),
+        oppstart: Oppstartstype = finnOppstartstype(tiltakstype.arenaKode),
         apentForPamelding: Boolean = true,
     ) = Deltakerliste(id, tiltakstype, navn, status, startDato, sluttDato, oppstart, apentForPamelding, arrangor)
 
@@ -472,8 +473,8 @@ object TestData {
         ArenaKode.JOBBK,
         ArenaKode.GRUPPEAMO,
         ArenaKode.GRUFAGYRKE,
-        -> Deltakerliste.Oppstartstype.FELLES
+        -> Oppstartstype.FELLES
 
-        else -> Deltakerliste.Oppstartstype.LOPENDE
+        else -> Oppstartstype.LOPENDE
     }
 }


### PR DESCRIPTION
legger samtidig til noen felter som trengs for å enklere filtrere bort visse deltakere fra tiltaksarrangør-bff

* Renamer mappere som blir brukt til å bygge opp payloaden og går bort fra "dto" som ofte blir brukt i synkron apier
* Forsøker å gi mer tydelig navngivning(Bør nok være noen strukturendringer på mappingen her men det er ikke tid til det nå)
* Disabler deltakerv2 consumer som ikke skal mer (men koden kan potensielt flyttes til ny consumer)
